### PR TITLE
fix: remove nested button from pulse button

### DIFF
--- a/src/components/ui/pulse-button.tsx
+++ b/src/components/ui/pulse-button.tsx
@@ -35,21 +35,23 @@ export interface PulseButtonProps
 
 const PulseButton = React.forwardRef<HTMLButtonElement, PulseButtonProps>(
   ({ className, variant, size, asChild = false, children, ...props }, ref) => {
-    const Comp = asChild ? "span" : "button";
-    
+    const content = (
+      <>
+        {children}
+        {variant === "pulse" && (
+          <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent -translate-x-full animate-[shimmer_2s_infinite] pointer-events-none" />
+        )}
+      </>
+    );
+
     return (
       <Button
         className={cn(pulseButtonVariants({ variant, size, className }))}
         ref={ref}
-        {...props}
         asChild={asChild}
+        {...props}
       >
-        <Comp>
-          {children}
-          {variant === "pulse" && (
-            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent -translate-x-full animate-[shimmer_2s_infinite] pointer-events-none" />
-          )}
-        </Comp>
+        {asChild ? <span>{content}</span> : content}
       </Button>
     );
   }


### PR DESCRIPTION
## Summary
- fix PulseButton to avoid nested button elements and support `asChild`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 20 problems)*

------
https://chatgpt.com/codex/tasks/task_e_688e873adf48833197aabe70cf59382b