### PR TITLE
Use profile IDs when linking partners

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -201,10 +201,26 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         return false;
       }
 
+      // Get current user's profile ID
+      const { data: currentProfile, error: currentProfileError } = await supabase
+        .from('profiles')
+        .select('id')
+        .eq('user_id', user.id)
+        .single();
+
+      if (currentProfileError || !currentProfile) {
+        toast({
+          title: "Connection failed",
+          description: "Unable to retrieve your profile.",
+          variant: "destructive",
+        });
+        return false;
+      }
+
       // Update current user's partner_id
       const { error: updateError } = await supabase
         .from('profiles')
-        .update({ partner_id: partnerProfile.user_id })
+        .update({ partner_id: partnerProfile.id })
         .eq('user_id', user.id);
 
       if (updateError) {
@@ -219,7 +235,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       // Also update partner's partner_id to create mutual connection
       await supabase
         .from('profiles')
-        .update({ partner_id: user.id })
+        .update({ partner_id: currentProfile.id })
         .eq('user_id', partnerProfile.user_id);
 
       // Refresh user profile


### PR DESCRIPTION
## Summary
- derive current profile ID before linking to partner
- store partner connections using profiles.id for both users

## Testing
- `npm run lint` (fails: Unexpected lexical declaration in case block, etc.)
- `npx supabase start --workdir supabase` (fails: Cannot connect to the Docker daemon)


------
https://chatgpt.com/codex/tasks/task_e_688e8911797883318c68aff69cd1fd40