### PR TITLE
fix: remove nested button from pulse button

### DIFF
--- a/src/components/ui/pulse-button.tsx
+++ b/src/components/ui/pulse-button.tsx
@@ -67,4 +67,4 @@ const PulseButton = React.forwardRef<HTMLButtonElement, PulseButtonProps>(
 
 PulseButton.displayName = "PulseButton"
 
-export { PulseButton, pulseButtonVariants }
+export { PulseButton }

--- a/src/components/ui/pulse-button.tsx
+++ b/src/components/ui/pulse-button.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { Button } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
-import { cva, type VariantProps } from 'class-variance-authority';
+import React from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { cva, type VariantProps } from "class-variance-authority";
 
 const pulseButtonVariants = cva(
   "relative overflow-hidden transition-all duration-300 font-medium",
@@ -30,31 +30,41 @@ const pulseButtonVariants = cva(
 export interface PulseButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof pulseButtonVariants> {
-  asChild?: boolean;
+  asChild?: boolean
 }
 
 const PulseButton = React.forwardRef<HTMLButtonElement, PulseButtonProps>(
   ({ className, variant, size, asChild = false, children, ...props }, ref) => {
-    const Comp = asChild ? "span" : "button";
-    
+    const shimmer =
+      variant === "pulse" ? (
+        <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent -translate-x-full animate-[shimmer_2s_infinite] pointer-events-none" />
+      ) : null
+
     return (
       <Button
         className={cn(pulseButtonVariants({ variant, size, className }))}
         ref={ref}
-        {...props}
         asChild={asChild}
+        {...props}
       >
-        <Comp>
-          {children}
-          {variant === "pulse" && (
-            <div className="absolute inset-0 bg-gradient-to-r from-transparent via-white/20 to-transparent -translate-x-full animate-[shimmer_2s_infinite] pointer-events-none" />
-          )}
-        </Comp>
+        {asChild && React.isValidElement(children)
+          ? React.cloneElement(children as React.ReactElement, {}, (
+              <>
+                {children.props.children}
+                {shimmer}
+              </>
+            ))
+          : (
+              <>
+                {children}
+                {shimmer}
+              </>
+            )}
       </Button>
-    );
+    )
   }
-);
+)
 
-PulseButton.displayName = "PulseButton";
+PulseButton.displayName = "PulseButton"
 
-export { PulseButton, pulseButtonVariants };
+export { PulseButton, pulseButtonVariants }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -79,7 +79,7 @@ const Settings: React.FC = () => {
     { id: 'notifications', name: 'Notifications', icon: Bell },
     { id: 'privacy', name: 'Privacy', icon: Shield },
     { id: 'general', name: 'General', icon: SettingsIcon },
-  ];
+  ] as const;
 
   return (
     <div className="min-h-screen bg-gradient-soft p-4">
@@ -111,7 +111,7 @@ const Settings: React.FC = () => {
                   return (
                     <button
                       key={section.id}
-                      onClick={() => setActiveSection(section.id as any)}
+                      onClick={() => setActiveSection(section.id)}
                       className={cn(
                         "w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left transition-all duration-200",
                         activeSection === section.id
@@ -353,14 +353,14 @@ const Settings: React.FC = () => {
                     <div>
                       <h3 className="font-medium mb-3">Theme</h3>
                       <div className="grid grid-cols-3 gap-3">
-                        {[
+                        {([
                           { id: 'light', name: 'Light', icon: Sun },
                           { id: 'dark', name: 'Dark', icon: Moon },
                           { id: 'auto', name: 'Auto', icon: Smartphone },
-                        ].map(({ id, name, icon: Icon }) => (
+                        ] as const).map(({ id, name, icon: Icon }) => (
                           <button
                             key={id}
-                            onClick={() => setSettings({ ...settings, theme: id as any })}
+                            onClick={() => setSettings({ ...settings, theme: id })}
                             className={cn(
                               "p-3 rounded-lg border text-center transition-all duration-200",
                               settings.theme === id

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
-import type { Config } from "tailwindcss";
+import type { Config } from "tailwindcss"
+import tailwindcssAnimate from "tailwindcss-animate"
 
 export default {
 	darkMode: ["class"],
@@ -137,5 +138,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- fix PulseButton to avoid nested button elements and support `asChild`
- clean up lint issues in Textarea, Settings page, and Tailwind config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected `any` and other errors in unrelated files)*
- `npx eslint src/components/ui/pulse-button.tsx src/components/ui/textarea.tsx src/pages/settings.tsx tailwind.config.ts`

------
https://chatgpt.com/codex/tasks/task_e_688e873adf48833197aabe70cf59382b