### PR TITLE
Fix messaging input, partner email naming, and enhance cn tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>secret-heartbeat-sync</title>
+    <title>Pulse</title>
     <meta name="description" content="Lovable Generated Project" />
     <meta name="author" content="Lovable" />
 
-    <meta property="og:title" content="secret-heartbeat-sync" />
+    <meta property="og:title" content="Pulse" />
     <meta property="og:description" content="Lovable Generated Project" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />

--- a/src/components/auth/auth-card.tsx
+++ b/src/components/auth/auth-card.tsx
@@ -22,7 +22,7 @@ export const AuthCard: React.FC<AuthCardProps> = ({ mode, onModeChange, classNam
     email: '',
     password: '',
     confirmPassword: '',
-    partnerCode: ''
+    partnerEmail: ''
   });
   
   const { login, register, connectPartner, user } = useAuth();
@@ -52,7 +52,7 @@ export const AuthCard: React.FC<AuthCardProps> = ({ mode, onModeChange, classNam
           success = await register(formData.name, formData.email, formData.password);
           break;
         case 'connect':
-          success = await connectPartner(formData.partnerCode, '');
+          success = await connectPartner(formData.partnerEmail, '');
           break;
       }
       
@@ -182,7 +182,7 @@ export const AuthCard: React.FC<AuthCardProps> = ({ mode, onModeChange, classNam
           )
         };
         
-      case 'connect':
+      case 'connect': {
         const copyToClipboard = () => {
           if (user?.email) {
             navigator.clipboard.writeText(user.email);
@@ -229,13 +229,13 @@ export const AuthCard: React.FC<AuthCardProps> = ({ mode, onModeChange, classNam
                 </div>
               </div>
               <div className="space-y-2">
-                <Label htmlFor="partnerCode">Partner's Email</Label>
-                <Input 
-                  id="partnerCode" 
-                  type="email" 
+                <Label htmlFor="partnerEmail">Partner's Email</Label>
+                <Input
+                  id="partnerEmail"
+                  type="email"
                   placeholder="partner@email.com"
-                  value={formData.partnerCode}
-                  onChange={(e) => handleInputChange('partnerCode', e.target.value)}
+                  value={formData.partnerEmail}
+                  onChange={(e) => handleInputChange('partnerEmail', e.target.value)}
                   required
                 />
               </div>
@@ -251,6 +251,7 @@ export const AuthCard: React.FC<AuthCardProps> = ({ mode, onModeChange, classNam
             </p>
           )
         };
+      }
     }
   };
 

--- a/src/components/messaging/message-center.tsx
+++ b/src/components/messaging/message-center.tsx
@@ -21,6 +21,16 @@ interface Message {
   sender_name?: string;
 }
 
+interface DatabaseMessage {
+  id: string;
+  content: string;
+  type: 'text' | 'emoji';
+  sender_id: string;
+  receiver_id: string;
+  created_at: string;
+  read_at: string | null;
+}
+
 interface MessageCenterProps {
   className?: string;
 }
@@ -57,15 +67,9 @@ export const MessageCenter: React.FC<MessageCenterProps> = ({ className }) => {
         },
         (payload) => {
           console.log('New message received:', payload);
-          const newMessage = payload.new as any;
+          const newMessage = payload.new as DatabaseMessage;
           const formattedMessage: Message = {
-            id: newMessage.id,
-            content: newMessage.content,
-            type: newMessage.type as 'text' | 'emoji',
-            sender_id: newMessage.sender_id,
-            receiver_id: newMessage.receiver_id,
-            created_at: newMessage.created_at,
-            read_at: newMessage.read_at,
+            ...newMessage,
             sender_name: newMessage.sender_id === user.id ? user.name : user.partnerName
           };
           setMessages(prev => [...prev, formattedMessage]);
@@ -81,9 +85,9 @@ export const MessageCenter: React.FC<MessageCenterProps> = ({ className }) => {
         },
         (payload) => {
           console.log('Message updated:', payload);
-          const updatedMessage = payload.new as any;
-          setMessages(prev => prev.map(msg => 
-            msg.id === updatedMessage.id 
+          const updatedMessage = payload.new as DatabaseMessage;
+          setMessages(prev => prev.map(msg =>
+            msg.id === updatedMessage.id
               ? { ...msg, read_at: updatedMessage.read_at }
               : msg
           ));
@@ -365,7 +369,7 @@ export const MessageCenter: React.FC<MessageCenterProps> = ({ className }) => {
               placeholder="Type your message..."
               value={newMessage}
               onChange={(e) => setNewMessage(e.target.value)}
-              onKeyPress={(e) => {
+              onKeyDown={(e) => {
                 if (e.key === 'Enter' && !e.shiftKey) {
                   e.preventDefault();
                   sendMessage(newMessage);

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -16,7 +16,7 @@ interface AuthContextType {
   isLoading: boolean;
   login: (email: string, password: string) => Promise<boolean>;
   register: (name: string, email: string, password: string) => Promise<boolean>;
-  connectPartner: (partnerCode: string, partnerName: string) => Promise<boolean>;
+  connectPartner: (partnerEmail: string, partnerName: string) => Promise<boolean>;
   logout: () => void;
 }
 
@@ -173,7 +173,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   };
 
-  const connectPartner = async (partnerCode: string, partnerName: string): Promise<boolean> => {
+  const connectPartner = async (partnerEmail: string, partnerName: string): Promise<boolean> => {
     setIsLoading(true);
     try {
       if (!user || !session) {
@@ -185,11 +185,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         return false;
       }
 
-      // Find partner by their unique code (we'll implement this as email for now)
+      // Find partner by email (used as a temporary unique code)
       const { data: partnerProfile, error: findError } = await supabase
         .from('profiles')
         .select('id, user_id, name')
-        .eq('email', partnerCode) // Using email as partner code for simplicity
+        .eq('email', partnerEmail)
         .single();
 
       if (findError || !partnerProfile) {

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -13,4 +13,8 @@ describe("cn", () => {
   it("supprime les doublons", () => {
     expect(cn("p-2", "p-4")).toBe("p-4");
   });
+
+  it("ignore les valeurs falsy", () => {
+    expect(cn("foo", null, undefined, false, "bar")).toBe("foo bar");
+  });
 });


### PR DESCRIPTION
## Summary
- replace legacy project name in index metadata
- use onKeyDown in message center input and type realtime payloads
- clarify partner connection by using partnerEmail
- cover falsy values in cn utility tests

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type in components/ui/command.tsx, @typescript-eslint/no-require-imports in tailwind.config.ts, and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_688e947e171c8331ae40df783f272481