### PR TITLE
feat: add push notification support

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,18 @@
+self.addEventListener('push', event => {
+  const data = event.data?.json() ?? {};
+  const title = data.title || 'Notification';
+  const options = {
+    body: data.body,
+    icon: data.icon || '/favicon.ico',
+    data: data.url ? { url: data.url } : undefined,
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', event => {
+  event.notification.close();
+  const url = event.notification.data?.url;
+  if (url) {
+    event.waitUntil(clients.openWindow(url));
+  }
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,48 +13,52 @@ import Messages from "./pages/messages";
 import Calendar from "./pages/calendar";
 import Settings from "./pages/settings";
 import NotFound from "./pages/NotFound";
+import { usePushNotifications } from "@/hooks/use-push-notifications";
 
 const queryClient = new QueryClient();
 
-const App = () => (
-  <ErrorBoundary>
-    <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <TooltipProvider>
-          <Toaster />
-          <Sonner />
-          <BrowserRouter>
-            <Routes>
-            <Route path="/" element={<Index />} />
-            <Route path="/auth" element={<Auth />} />
-            <Route path="/dashboard" element={
-              <ProtectedRoute>
-                <Dashboard />
-              </ProtectedRoute>
-            } />
-            <Route path="/messages" element={
-              <ProtectedRoute>
-                <Messages />
-              </ProtectedRoute>
-            } />
-            <Route path="/calendar" element={
-              <ProtectedRoute>
-                <Calendar />
-              </ProtectedRoute>
-            } />
-            <Route path="/settings" element={
-              <ProtectedRoute>
-                <Settings />
-              </ProtectedRoute>
-            } />
-            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-              <Route path="*" element={<NotFound />} />
-            </Routes>
-          </BrowserRouter>
-        </TooltipProvider>
-      </AuthProvider>
-    </QueryClientProvider>
-  </ErrorBoundary>
-);
+const App = () => {
+  usePushNotifications();
+  return (
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <TooltipProvider>
+            <Toaster />
+            <Sonner />
+            <BrowserRouter>
+              <Routes>
+              <Route path="/" element={<Index />} />
+              <Route path="/auth" element={<Auth />} />
+              <Route path="/dashboard" element={
+                <ProtectedRoute>
+                  <Dashboard />
+                </ProtectedRoute>
+              } />
+              <Route path="/messages" element={
+                <ProtectedRoute>
+                  <Messages />
+                </ProtectedRoute>
+              } />
+              <Route path="/calendar" element={
+                <ProtectedRoute>
+                  <Calendar />
+                </ProtectedRoute>
+              } />
+              <Route path="/settings" element={
+                <ProtectedRoute>
+                  <Settings />
+                </ProtectedRoute>
+              } />
+              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </BrowserRouter>
+          </TooltipProvider>
+        </AuthProvider>
+      </QueryClientProvider>
+    </ErrorBoundary>
+  );
+};
 
 export default App;

--- a/src/hooks/use-push-notifications.ts
+++ b/src/hooks/use-push-notifications.ts
@@ -1,0 +1,53 @@
+import { useEffect } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+
+function urlBase64ToUint8Array(base64String: string) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}
+
+export function usePushNotifications() {
+  useEffect(() => {
+    if (!('serviceWorker' in navigator)) return;
+
+    const register = async () => {
+      try {
+        const registration = await navigator.serviceWorker.register('/sw.js');
+
+        let subscription = await registration.pushManager.getSubscription();
+        if (!subscription) {
+          const publicKey = import.meta.env.VITE_VAPID_PUBLIC_KEY;
+          if (!publicKey) {
+            console.warn('VAPID public key is not set');
+            return;
+          }
+          subscription = await registration.pushManager.subscribe({
+            userVisibleOnly: true,
+            applicationServerKey: urlBase64ToUint8Array(publicKey),
+          });
+        }
+
+        const { data: { user } } = await supabase.auth.getUser();
+        if (user) {
+          const { endpoint, keys } = subscription.toJSON();
+          await supabase.from('push_subscriptions').insert({
+            endpoint,
+            auth: keys?.auth ?? '',
+            p256dh: keys?.p256dh ?? '',
+            user_id: user.id,
+          });
+        }
+      } catch (error) {
+        console.error('Error registering push notifications', error);
+      }
+    };
+
+    register();
+  }, []);
+}


### PR DESCRIPTION
## Summary
- handle push and notification clicks via service worker
- register service worker and store push subscriptions in Supabase
- hook into app to initialize push notifications

## Testing
- `npm run lint` *(fails: no-empty-object-type, no-explicit-any, no-require-imports)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f293940888331b6600fe212588c49