### PR TITLE
feat: add Supabase time slots

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -108,6 +108,36 @@ export type Database = {
           user_id?: string
         }
         Relationships: []
+      },
+      time_slots: {
+        Row: {
+          id: string
+          user_id: string
+          start: string
+          end: string
+          date: string
+          type: string
+          title: string | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          start: string
+          end: string
+          date: string
+          type: string
+          title?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          start?: string
+          end?: string
+          date?: string
+          type?: string
+          title?: string | null
+        }
+        Relationships: []
       }
     }
     Views: {

--- a/supabase/migrations/20250723120000-c28271d9-ac8b-41ad-b5b4-7b8f091e0b90.sql
+++ b/supabase/migrations/20250723120000-c28271d9-ac8b-41ad-b5b4-7b8f091e0b90.sql
@@ -1,0 +1,20 @@
+-- Create time_slots table
+CREATE TABLE public.time_slots (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  "start" TIME NOT NULL,
+  "end" TIME NOT NULL,
+  date DATE NOT NULL,
+  type TEXT NOT NULL CHECK (type IN ('mutual','suggested','booked')),
+  title TEXT
+);
+
+-- Enable Row Level Security
+ALTER TABLE public.time_slots ENABLE ROW LEVEL SECURITY;
+
+-- RLS policy: users manage their own time slots
+CREATE POLICY "Users can manage their own time slots"
+ON public.time_slots
+FOR ALL
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add Supabase migration for time_slots and RLS
- integrate shared calendar with Supabase CRUD operations
- extend Supabase types for time_slots table

## Testing
- `npm test`
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; Unexpected any. Specify a different type; A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f2938564c8331a71ffcd50f5c8a26