### PR TITLE
refactor: remove partner name parameter

### DIFF
--- a/src/components/auth/auth-card.tsx
+++ b/src/components/auth/auth-card.tsx
@@ -52,7 +52,7 @@ export const AuthCard: React.FC<AuthCardProps> = ({ mode, onModeChange, classNam
           success = await register(formData.name, formData.email, formData.password);
           break;
         case 'connect':
-          success = await connectPartner(formData.partnerEmail, '');
+          success = await connectPartner(formData.partnerEmail);
           break;
       }
       

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -16,7 +16,7 @@ interface AuthContextType {
   isLoading: boolean;
   login: (email: string, password: string) => Promise<boolean>;
   register: (name: string, email: string, password: string) => Promise<boolean>;
-  connectPartner: (partnerEmail: string, partnerName: string) => Promise<boolean>;
+  connectPartner: (partnerEmail: string) => Promise<boolean>;
   logout: () => void;
 }
 
@@ -173,7 +173,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   };
 
-  const connectPartner = async (partnerEmail: string, partnerName: string): Promise<boolean> => {
+  const connectPartner = async (partnerEmail: string): Promise<boolean> => {
     setIsLoading(true);
     try {
       if (!user || !session) {


### PR DESCRIPTION
## Summary
- drop partnerName argument from auth context and calls

## Testing
- `npm run lint` *(fails: Fast refresh warnings, no-empty-object-type, no-require-imports)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f51c0127c8331b75d83db531afb19