### PR TITLE
Add central pulse button with haptic feedback

### DIFF
--- a/src/components/dashboard/central-pulse-button.tsx
+++ b/src/components/dashboard/central-pulse-button.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { Heart, Check } from 'lucide-react';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+import { cn } from '@/lib/utils';
+
+interface CentralPulseButtonProps {
+  className?: string;
+}
+
+type PulseState = 'idle' | 'sending' | 'sent';
+
+export const CentralPulseButton: React.FC<CentralPulseButtonProps> = ({ className }) => {
+  const { user } = useAuth();
+  const [state, setState] = useState<PulseState>('idle');
+
+  const handleClick = async () => {
+    if (!user || !user.partnerId) return;
+
+    navigator.vibrate?.(50);
+
+    setState('sending');
+
+    try {
+      await supabase.from('messages').insert({
+        sender_id: user.id,
+        receiver_id: user.partnerId,
+        content: 'pulse',
+        type: 'pulse'
+      });
+      setState('sent');
+    } catch (error) {
+      console.error('Error sending pulse:', error);
+      setState('idle');
+      return;
+    }
+
+    setTimeout(() => {
+      setState('idle');
+    }, 1000);
+  };
+
+  return (
+    <button
+      aria-label="Send Pulse"
+      onClick={handleClick}
+      className={cn(
+        'relative w-16 h-16 rounded-full flex items-center justify-center bg-gradient-primary text-primary-foreground shadow-glow',
+        state !== 'idle' && 'animate-pulse',
+        className
+      )}
+    >
+      {state === 'sent' ? (
+        <Check className="w-8 h-8" />
+      ) : (
+        <Heart className="w-8 h-8" />
+      )}
+    </button>
+  );
+};
+
+export default CentralPulseButton;

--- a/src/components/dashboard/pulse-status.tsx
+++ b/src/components/dashboard/pulse-status.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { PulseButton } from '@/components/ui/pulse-button';
+import { CentralPulseButton } from './central-pulse-button';
 import { StatusIndicator } from '@/components/ui/status-indicator';
 import { Heart, Moon, Coffee, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -111,9 +111,9 @@ export const PulseStatusCard: React.FC<PulseStatusProps> = ({ className }) => {
             <p className="text-sm text-muted-foreground mb-3">
               Perfect timing! You're both available for connection.
             </p>
-            <PulseButton variant="pulse" size="sm" className="w-full">
-              Send Pulse
-            </PulseButton>
+            <div className="flex justify-center">
+              <CentralPulseButton />
+            </div>
           </div>
         )}
       </CardContent>


### PR DESCRIPTION
## Summary
- add CentralPulseButton with haptic feedback, pulse animation, and Supabase logging
- integrate CentralPulseButton into dashboard pulse status quick actions

## Testing
- `npm test`
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype)*


------
https://chatgpt.com/codex/tasks/task_e_688f55685c6c8331b4cd3118d99fe3c9