### PR TITLE
feat: add splash screen

### DIFF
--- a/src/components/splash-screen.tsx
+++ b/src/components/splash-screen.tsx
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+interface SplashScreenProps {
+  onFinish: () => void;
+}
+
+const SplashScreen: React.FC<SplashScreenProps> = ({ onFinish }) => {
+  const finished = useRef(false);
+
+  const finish = useCallback(() => {
+    if (finished.current) return;
+    finished.current = true;
+    onFinish();
+  }, [onFinish]);
+
+  useEffect(() => {
+    const timer = setTimeout(finish, 1000);
+    const events: Array<keyof DocumentEventMap> = ['click', 'keydown', 'touchstart'];
+    events.forEach((e) => window.addEventListener(e, finish));
+    return () => {
+      clearTimeout(timer);
+      events.forEach((e) => window.removeEventListener(e, finish));
+    };
+  }, [finish]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background">
+      <img
+        src="/placeholder.svg"
+        alt="Logo"
+        className="h-32 w-32 animate-pulse"
+        style={{ animationDuration: '1s' }}
+      />
+    </div>
+  );
+};
+
+export default SplashScreen;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,22 @@
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import { createRoot } from 'react-dom/client';
+import { useCallback, useState } from 'react';
+import App from './App.tsx';
+import SplashScreen from './components/splash-screen';
+import './index.css';
 
-createRoot(document.getElementById("root")!).render(<App />);
+const Main = () => {
+  const [showSplash, setShowSplash] = useState(
+    () => localStorage.getItem('splashShown') !== 'true'
+  );
+
+  const handleFinish = useCallback(() => {
+    localStorage.setItem('splashShown', 'true');
+    setShowSplash(false);
+  }, []);
+
+  return showSplash ? <SplashScreen onFinish={handleFinish} /> : <App />;
+};
+
+export default Main;
+
+createRoot(document.getElementById('root')!).render(<Main />);


### PR DESCRIPTION
## Summary
- add splash screen component with 1s animation and interaction handling
- gate app rendering until splash completes and persist flag in localStorage

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688f6242af608331bd413aab69aee25d