### PR TITLE
Add snooze toggle and suppress pulses during downtime

### DIFF
--- a/src/components/dashboard/central-pulse-button.tsx
+++ b/src/components/dashboard/central-pulse-button.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Heart, Check } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
 
 interface CentralPulseButtonProps {
@@ -13,9 +14,26 @@ type PulseState = 'idle' | 'sending' | 'sent';
 export const CentralPulseButton: React.FC<CentralPulseButtonProps> = ({ className }) => {
   const { user } = useAuth();
   const [state, setState] = useState<PulseState>('idle');
+  const { toast } = useToast();
 
   const handleClick = async () => {
     if (!user || !user.partnerId) return;
+
+    const now = new Date();
+    if (user.snoozeUntil && new Date(user.snoozeUntil) > now) {
+      toast({
+        title: 'Snoozed',
+        description: 'You are currently snoozed.',
+      });
+      return;
+    }
+    if (user.partnerSnoozeUntil && new Date(user.partnerSnoozeUntil) > now) {
+      toast({
+        title: 'Partner snoozed',
+        description: 'Your partner is currently snoozed.',
+      });
+      return;
+    }
 
     navigator.vibrate?.(50);
 

--- a/src/components/dashboard/pulse-status.tsx
+++ b/src/components/dashboard/pulse-status.tsx
@@ -4,6 +4,7 @@ import { CentralPulseButton } from './central-pulse-button';
 import { StatusIndicator } from '@/components/ui/status-indicator';
 import { Heart, Moon, Coffee, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { SnoozeToggle } from './snooze-toggle';
 
 type PulseStatus = 'active' | 'away' | 'offline';
 
@@ -45,6 +46,8 @@ export const PulseStatusCard: React.FC<PulseStatusProps> = ({ className }) => {
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
+        <SnoozeToggle />
+
         {/* Partner Status */}
         <div className="space-y-3">
           <h3 className="font-medium text-foreground">Your Partner</h3>

--- a/src/components/dashboard/snooze-toggle.tsx
+++ b/src/components/dashboard/snooze-toggle.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { Button } from '@/components/ui/button';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from '@/hooks/use-toast';
+import { format } from 'date-fns';
+
+export const SnoozeToggle: React.FC = () => {
+  const { user, refreshUser } = useAuth();
+  const { toast } = useToast();
+
+  if (!user) return null;
+
+  const isSnoozed = user.snoozeUntil && new Date(user.snoozeUntil) > new Date();
+
+  const updateSnooze = async (hours: number | null) => {
+    if (!user) return;
+    try {
+      const snooze_until = hours
+        ? new Date(Date.now() + hours * 60 * 60 * 1000).toISOString()
+        : null;
+      await supabase
+        .from('profiles')
+        .update({ snooze_until })
+        .eq('user_id', user.id);
+      await refreshUser();
+      if (hours && user.partnerId) {
+        try {
+          await supabase.functions.invoke('send-push', {
+            body: {
+              receiver_id: user.partnerId,
+              title: 'Pulse',
+              body: `${user.name} est occupé·e pour l’instant`,
+            },
+          });
+        } catch (error) {
+          console.error('Error sending push notification:', error);
+        }
+      }
+      toast({
+        title: 'Snooze updated',
+        description: hours
+          ? `Notifications muted for ${hours} hours.`
+          : 'Snooze disabled.',
+      });
+    } catch (error) {
+      console.error('Error updating snooze:', error);
+      toast({
+        title: 'Error',
+        description: 'Failed to update snooze.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  if (isSnoozed) {
+    return (
+      <div className="space-y-2">
+        <h3 className="font-medium text-foreground">Snooze</h3>
+        <p className="text-sm text-muted-foreground">
+          Snoozed until {format(new Date(user.snoozeUntil!), 'PPpp')}
+        </p>
+        <Button size="sm" onClick={() => updateSnooze(null)}>
+          Cancel Snooze
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <h3 className="font-medium text-foreground">Snooze</h3>
+      <ToggleGroup
+        type="single"
+        className="grid grid-cols-2 gap-2"
+        onValueChange={(val) => {
+          if (val === '8') updateSnooze(8);
+          if (val === '24') updateSnooze(24);
+        }}
+      >
+        <ToggleGroupItem value="8" className="w-full">
+          8h
+        </ToggleGroupItem>
+        <ToggleGroupItem value="24" className="w-full">
+          24h
+        </ToggleGroupItem>
+      </ToggleGroup>
+    </div>
+  );
+};
+
+export default SnoozeToggle;
+

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -51,6 +51,7 @@ export type Database = {
           id: string
           name: string
           partner_id: string | null
+          snooze_until: string | null
           updated_at: string
           user_id: string
         }
@@ -60,6 +61,7 @@ export type Database = {
           id?: string
           name: string
           partner_id?: string | null
+          snooze_until?: string | null
           updated_at?: string
           user_id: string
         }
@@ -69,6 +71,7 @@ export type Database = {
           id?: string
           name?: string
           partner_id?: string | null
+          snooze_until?: string | null
           updated_at?: string
           user_id?: string
         }

--- a/supabase/migrations/20250801000000-add-snooze.sql
+++ b/supabase/migrations/20250801000000-add-snooze.sql
@@ -1,0 +1,3 @@
+-- Add snooze_until column to profiles
+ALTER TABLE public.profiles
+ADD COLUMN snooze_until TIMESTAMP WITH TIME ZONE;


### PR DESCRIPTION
## Summary
- add `snooze_until` column and types for profiles
- introduce dashboard SnoozeToggle with 8h/24h options and push notification
- prevent pulse/message sending while either user is snoozed

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f62419bb88331a50754e5782a9397