### PR TITLE
feat: add onboarding options

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,19 @@
+const translations = {
+  en: {
+    createAccount: 'Create account',
+    joinPartner: 'Join partner',
+  },
+  fr: {
+    createAccount: 'Créer un compte',
+    joinPartner: 'Rejoindre mon/ma partenaire',
+  },
+} as const;
+
+export type TranslationKey = keyof typeof translations['en'];
+
+export const useTranslation = () => {
+  const lang = navigator.language?.toLowerCase().startsWith('fr') ? 'fr' : 'en';
+  const t = (key: TranslationKey) => translations[lang][key];
+  return { t, lang };
+};
+

--- a/src/onboarding/StepIntro.tsx
+++ b/src/onboarding/StepIntro.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Carousel, CarouselContent, CarouselItem, CarouselPrevious, CarouselNext } from '@/components/ui/carousel';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { PulseButton } from '@/components/ui/pulse-button';
+import { useTranslation } from '@/i18n';
 
 const items = [
   { title: 'Code Pulse', description: 'Exprimez vos envies par pulsations discrètes.' },
@@ -12,6 +13,7 @@ const items = [
 
 export const StepIntro: React.FC = () => {
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   return (
     <div className="space-y-8">
@@ -33,9 +35,12 @@ export const StepIntro: React.FC = () => {
         <CarouselPrevious />
         <CarouselNext />
       </Carousel>
-      <div className="flex justify-center">
-        <PulseButton onClick={() => navigate('/auth?mode=connect')}>
-          Inviter mon/ma partenaire
+      <div className="flex flex-col sm:flex-row justify-center gap-4">
+        <PulseButton onClick={() => navigate('/auth?mode=register')}>
+          {t('createAccount')}
+        </PulseButton>
+        <PulseButton variant="ghost" onClick={() => navigate('/auth?mode=connect')}>
+          {t('joinPartner')}
         </PulseButton>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add i18n helper for basic French and English strings
- show register and partner buttons on onboarding intro

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any; An interface declaring no members is equivalent to its supertype; A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f624197248331962e38be0ffec8b5