### PR TITLE
feat: enhance pulse notifications

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,18 +1,51 @@
+let badgeCount = 0;
+
 self.addEventListener('push', event => {
   const data = event.data?.json() ?? {};
-  const title = data.title || 'Notification';
+  const isPulse = data.type === 'pulse';
+  const title = isPulse ? data.emoji || '✨' : data.title || 'Notification';
+
   const options = {
-    body: data.body,
     icon: data.icon || '/favicon.ico',
     data: data.url ? { url: data.url } : undefined,
+    actions: data.url ? [{ action: 'open', title: 'Open' }] : undefined,
   };
-  event.waitUntil(self.registration.showNotification(title, options));
+
+  if (isPulse) {
+    options.body = 'Slide to open';
+  } else if (data.body) {
+    options.body = data.body;
+  }
+
+  const promiseChain = (async () => {
+    const clientList = await clients.matchAll({ type: 'window', includeUncontrolled: true });
+    const isClientFocused = clientList.some(client => client.focused);
+
+    if (!isClientFocused && 'setAppBadge' in self.registration) {
+      badgeCount += 1;
+      try {
+        await self.registration.setAppBadge(badgeCount);
+      } catch (err) {
+        // Ignore errors setting badge
+      }
+    }
+
+    await self.registration.showNotification(title, options);
+  })();
+
+  event.waitUntil(promiseChain);
 });
 
 self.addEventListener('notificationclick', event => {
   event.notification.close();
   const url = event.notification.data?.url;
-  if (url) {
+
+  if (url && (event.action === 'open' || event.action === '')) {
     event.waitUntil(clients.openWindow(url));
+  }
+
+  if ('clearAppBadge' in self.registration) {
+    self.registration.clearAppBadge();
+    badgeCount = 0;
   }
 });


### PR DESCRIPTION
## Summary
- show emoji-only notifications for incoming pulses
- add slide-to-open action and badge incrementing

## Testing
- `npm test`
- `npm run lint` *(fails: Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components; An interface declaring no members is equivalent to its supertype; A `require()` style import is forbidden)*
- `npx eslint public/sw.js`


------
https://chatgpt.com/codex/tasks/task_e_688f623fe1748331ae3098c3e1113b21