### PR TITLE
Add accept/defer options for calendar suggestions

### DIFF
--- a/src/lib/reminders.ts
+++ b/src/lib/reminders.ts
@@ -1,0 +1,18 @@
+import { supabase } from '@/integrations/supabase/client';
+
+interface ReminderSlot {
+  id: string;
+  date: string;
+  start: string;
+}
+
+export const scheduleReminder = async (userId: string, slot: ReminderSlot) => {
+  const slotTime = new Date(`${slot.date}T${slot.start}`);
+  const remindAt = new Date(slotTime.getTime() - 2 * 60 * 60 * 1000);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await (supabase.from as any)('reminders').insert({
+    user_id: userId,
+    time_slot_id: slot.id,
+    remind_at: remindAt.toISOString(),
+  });
+};


### PR DESCRIPTION
## Summary
- add "Accepter" and "Plus tard" choices for suggested time slots
- store decisions in `time_slots` and schedule a reminder 2h before next mutual slot

## Testing
- `npm test`
- `npm run lint` *(fails: src/components/ui/textarea.tsx no-empty-object-type; tailwind.config.ts no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_688f623fae948331b635529372af0be6