### PR TITLE
Handle partner profile update errors

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -245,10 +245,19 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       }
 
       // Also update partner's partner_id to create mutual connection
-      await supabase
+      const { error: partnerUpdateError } = await supabase
         .from('profiles')
         .update({ partner_id: currentProfile.id })
         .eq('user_id', partnerProfile.user_id);
+
+      if (partnerUpdateError) {
+        toast({
+          title: "Connection failed",
+          description: "Unable to connect with partner. Please try again.",
+          variant: "destructive",
+        });
+        return false;
+      }
 
       // Refresh user profile
       await fetchUserProfile(session.user);
@@ -327,10 +336,19 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         return false;
       }
 
-      await supabase
+      const { error: partnerUpdateError } = await supabase
         .from('profiles')
         .update({ partner_id: currentProfile.id })
         .eq('user_id', partnerProfile.user_id);
+
+      if (partnerUpdateError) {
+        toast({
+          title: "Connection failed",
+          description: "Unable to connect with partner. Please try again.",
+          variant: "destructive",
+        });
+        return false;
+      }
 
       await fetchUserProfile(session.user);
 


### PR DESCRIPTION
## Summary
- add error handling when updating partner profile in `connectPartner`
- mirror error handling in `connectByCode`

## Testing
- `npm run lint` *(fails: Unexpected any, no-empty-object-type, etc.)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f78cb42148331b48b177355fed14b