### PR TITLE
fix: register toast listener once

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- register toast state listener only once using empty dependency array

## Testing
- `npm test`
- `npm run lint` *(fails: 18 problems, 6 errors, 12 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688f78ccc1f4833187cac4b59d52000a