### PR TITLE
chore: remove unused useEffect import from toast hook

### DIFF
--- a/src/hooks/use-toast-notification.ts
+++ b/src/hooks/use-toast-notification.ts
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useToast } from '@/hooks/use-toast';
 
 interface ToastNotificationOptions {


### PR DESCRIPTION
## Summary
- remove unused `useEffect` import in `use-toast-notification`

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_688f78cd7d28833180ec4ea6849cfbfc