### PR TITLE
feat: add language switcher

### DIFF
--- a/src/components/ui/language-switcher.tsx
+++ b/src/components/ui/language-switcher.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { useTranslation } from '@/i18n';
+
+export const LanguageSwitcher: React.FC = () => {
+  const { lang, setLang } = useTranslation();
+
+  return (
+    <Select value={lang} onValueChange={(value: string) => setLang(value as 'en' | 'fr')}>
+      <SelectTrigger className="w-[100px]">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="en">English</SelectItem>
+        <SelectItem value="fr">Français</SelectItem>
+      </SelectContent>
+    </Select>
+  );
+};

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 const translations = {
   en: {
     createAccount: 'Create account',
@@ -10,10 +12,37 @@ const translations = {
 } as const;
 
 export type TranslationKey = keyof typeof translations['en'];
+type Lang = keyof typeof translations;
+
+const STORAGE_KEY = 'lang';
+
+let currentLang: Lang = (typeof localStorage !== 'undefined' &&
+  (localStorage.getItem(STORAGE_KEY) as Lang | null)) ||
+  (navigator.language?.toLowerCase().startsWith('fr') ? 'fr' : 'en');
+
+const listeners = new Set<() => void>();
+
+export const setLang = (lang: Lang) => {
+  currentLang = lang;
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(STORAGE_KEY, lang);
+  }
+  listeners.forEach((l) => l());
+};
 
 export const useTranslation = () => {
-  const lang = navigator.language?.toLowerCase().startsWith('fr') ? 'fr' : 'en';
+  const [lang, setLangState] = useState<Lang>(currentLang);
+
+  useEffect(() => {
+    const listener = () => setLangState(currentLang);
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
   const t = (key: TranslationKey) => translations[lang][key];
-  return { t, lang };
+  return { t, lang, setLang };
 };
+
 

--- a/src/onboarding/StepIntro.tsx
+++ b/src/onboarding/StepIntro.tsx
@@ -4,6 +4,7 @@ import { Carousel, CarouselContent, CarouselItem, CarouselPrevious, CarouselNext
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { PulseButton } from '@/components/ui/pulse-button';
 import { useTranslation } from '@/i18n';
+import { LanguageSwitcher } from '@/components/ui/language-switcher';
 
 const items = [
   { title: 'Code Pulse', description: 'Exprimez vos envies par pulsations discrètes.' },
@@ -17,6 +18,9 @@ export const StepIntro: React.FC = () => {
 
   return (
     <div className="space-y-8">
+      <div className="flex justify-end">
+        <LanguageSwitcher />
+      </div>
       <Carousel className="w-full max-w-md mx-auto">
         <CarouselContent>
           {items.map((item, index) => (

--- a/src/pages/auth.tsx
+++ b/src/pages/auth.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { AuthCard } from '@/components/auth/auth-card';
 import heroImage from '@/assets/pulse-hero.jpg';
 import { useSearchParams } from 'react-router-dom';
+import { LanguageSwitcher } from '@/components/ui/language-switcher';
 
 const Auth = () => {
   const [searchParams] = useSearchParams();
@@ -19,7 +20,10 @@ const Auth = () => {
     <div className="min-h-screen bg-gradient-soft">
       {/* Hero Section */}
       <div className="relative overflow-hidden">
-        <div 
+        <div className="absolute top-4 right-4 z-20">
+          <LanguageSwitcher />
+        </div>
+        <div
           className="absolute inset-0 bg-cover bg-center bg-no-repeat opacity-20"
           style={{ backgroundImage: `url(${heroImage})` }}
         />


### PR DESCRIPTION
## Summary
- add language switcher component with English and French
- persist language selection and expose setter in i18n
- render language switcher on auth and onboarding intro screens

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688f798777e88331b68bcfe2fd9fbda6