### PR TITLE
Add invite partner button and translations

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -2,10 +2,12 @@ const translations = {
   en: {
     createAccount: 'Create account',
     joinPartner: 'Join partner',
+    invitePartner: 'Invite partner',
   },
   fr: {
     createAccount: 'Créer un compte',
     joinPartner: 'Rejoindre mon/ma partenaire',
+    invitePartner: 'Inviter mon/ma partenaire',
   },
 } as const;
 

--- a/src/onboarding/StepIntro.tsx
+++ b/src/onboarding/StepIntro.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Carousel, CarouselContent, CarouselItem, CarouselPrevious, CarouselNext } from '@/components/ui/carousel';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { PulseButton } from '@/components/ui/pulse-button';
+import { useAuth } from '@/contexts/AuthContext';
 import { useTranslation } from '@/i18n';
 
 const items = [
@@ -14,6 +15,15 @@ const items = [
 export const StepIntro: React.FC = () => {
   const navigate = useNavigate();
   const { t } = useTranslation();
+  const { user } = useAuth();
+
+  const handleInvite = () => {
+    if (user) {
+      navigate('/pair');
+    } else {
+      navigate('/auth?mode=connect');
+    }
+  };
 
   return (
     <div className="space-y-8">
@@ -41,6 +51,11 @@ export const StepIntro: React.FC = () => {
         </PulseButton>
         <PulseButton variant="ghost" onClick={() => navigate('/auth?mode=connect')}>
           {t('joinPartner')}
+        </PulseButton>
+      </div>
+      <div className="flex justify-center">
+        <PulseButton onClick={handleInvite}>
+          {t('invitePartner')}
         </PulseButton>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add invite partner button on onboarding intro that navigates to pairing page when logged in
- wire button to connect mode when user is unauthenticated
- include invitePartner translation for English and French

## Testing
- `npm test`
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type in textarea.tsx; @typescript-eslint/no-require-imports in tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_688f7988382c8331a2a12a9cc046b065