### PR TITLE
Add sending halo to central pulse button

### DIFF
--- a/src/components/dashboard/central-pulse-button.tsx
+++ b/src/components/dashboard/central-pulse-button.tsx
@@ -64,10 +64,13 @@ export const CentralPulseButton: React.FC<CentralPulseButtonProps> = ({ classNam
       onClick={handleClick}
       className={cn(
         'relative w-16 h-16 rounded-full flex items-center justify-center bg-gradient-primary text-primary-foreground shadow-glow',
-        state !== 'idle' && 'animate-pulse',
+        state === 'sending' && 'animate-pulse',
         className
       )}
     >
+      {state === 'sending' && (
+        <span className="pointer-events-none absolute inset-0 rounded-full bg-primary/40 animate-ping" />
+      )}
       {state === 'sent' ? (
         <Check className="w-8 h-8" />
       ) : (


### PR DESCRIPTION
## Summary
- show animated halo when pulse is sending
- replace halo with check icon on send completion

## Testing
- `npm test`
- `npm run lint` *(fails: no-empty-object-type, no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_688f79883ea4833197711d0daee7b430