### PR TITLE
feat: add paywall and premium gating

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "./contexts/AuthContext";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
+import NetworkStatusBanner from "./components/ui/network-status-banner";
 import ErrorBoundary from "./components/ui/error-boundary";
 import Index from "./pages/Index";
 import Auth from "./pages/auth";
@@ -14,6 +15,7 @@ import Calendar from "./pages/calendar";
 import Settings from "./pages/settings";
 import NotFound from "./pages/NotFound";
 import PairPage from "./pages/pair";
+import Paywall from "./pages/paywall";
 import { usePushNotifications } from "@/hooks/use-push-notifications";
 
 const queryClient = new QueryClient();
@@ -25,14 +27,16 @@ const App = () => {
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
           <TooltipProvider>
+            <NetworkStatusBanner />
             <Toaster />
             <Sonner />
             <BrowserRouter>
               <Routes>
               <Route path="/" element={<Index />} />
               <Route path="/auth" element={<Auth />} />
+              <Route path="/paywall" element={<Paywall />} />
               <Route path="/dashboard" element={
-                <ProtectedRoute>
+                <ProtectedRoute requiresPremium>
                   <Dashboard />
                 </ProtectedRoute>
               } />

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -4,9 +4,10 @@ import { useAuth } from '@/contexts/AuthContext';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
+  requiresPremium?: boolean;
 }
 
-const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
+const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children, requiresPremium }) => {
   const { user, isLoading } = useAuth();
 
   if (isLoading) {
@@ -24,6 +25,10 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
 
   if (!user) {
     return <Navigate to="/auth" replace />;
+  }
+
+  if (requiresPremium && !user.isPremium) {
+    return <Navigate to="/paywall" replace />;
   }
 
   return <>{children}</>;

--- a/src/components/ui/network-status-banner.tsx
+++ b/src/components/ui/network-status-banner.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from 'react';
+
+const NetworkStatusBanner = () => {
+  const [isOnline, setIsOnline] = useState<boolean>(navigator.onLine);
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  if (isOnline) return null;
+
+  return (
+    <div className="w-full bg-red-600 text-white text-center py-2 text-sm">
+      Connexion requise
+    </div>
+  );
+};
+
+export default NetworkStatusBanner;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -11,6 +11,7 @@ interface User {
   partnerName?: string;
   snoozeUntil?: string | null;
   partnerSnoozeUntil?: string | null;
+  isPremium?: boolean;
 }
 
 interface AuthContextType {
@@ -93,7 +94,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           partnerId: profile.partner_id,
           partnerName: profile.partner?.name,
           snoozeUntil: profile.snooze_until,
-          partnerSnoozeUntil: profile.partner?.snooze_until
+          partnerSnoozeUntil: profile.partner?.snooze_until,
+          isPremium: profile.is_premium
         });
       }
     } catch (error) {

--- a/src/pages/paywall.tsx
+++ b/src/pages/paywall.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { PulseButton } from '@/components/ui/pulse-button';
+import { Heart, Shield, Sparkles } from 'lucide-react';
+
+const Paywall = () => {
+  return (
+    <div className="min-h-screen bg-gradient-soft flex flex-col">
+      <div className="flex-1 container mx-auto px-4 py-12 max-w-2xl">
+        <h1 className="text-3xl font-bold text-center mb-8">Pulse Premium</h1>
+
+        <div className="space-y-4 mb-10">
+          <div className="flex items-center gap-3">
+            <Heart className="w-5 h-5 text-primary" />
+            <span>Moments intimes renforcés</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <Shield className="w-5 h-5 text-primary" />
+            <span>Confidentialité assurée</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <Sparkles className="w-5 h-5 text-primary" />
+            <span>Fonctionnalités exclusives</span>
+          </div>
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-6 mb-10">
+          <div className="p-6 rounded-lg border text-center bg-background">
+            <h2 className="text-xl font-semibold mb-2">Mensuel</h2>
+            <p className="text-3xl font-bold mb-4">4,99€</p>
+            <p className="text-sm text-muted-foreground">Facturation mensuelle</p>
+          </div>
+          <div className="p-6 rounded-lg border text-center bg-background">
+            <h2 className="text-xl font-semibold mb-2">À vie</h2>
+            <p className="text-3xl font-bold mb-4">49,99€</p>
+            <p className="text-sm text-muted-foreground">Paiement unique</p>
+          </div>
+        </div>
+
+        <div className="text-center">
+          <PulseButton size="lg">Essai 7 jours</PulseButton>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Paywall;


### PR DESCRIPTION
## Summary
- add paywall page with benefits, pricing, and 7-day trial CTA
- show offline banner when network is disconnected
- gate premium areas behind paywall for non-premium users

## Testing
- `npm run lint` (fails: An interface declaring no members is equivalent to its supertype, A `require()` style import is forbidden)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f868691e883318a13e37012c01d28