### PR TITLE
feat: add pulse history page with settings toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import Calendar from "./pages/calendar";
 import Settings from "./pages/settings";
 import NotFound from "./pages/NotFound";
 import PairPage from "./pages/pair";
+import History from "./pages/history";
 import { usePushNotifications } from "@/hooks/use-push-notifications";
 
 const queryClient = new QueryClient();
@@ -44,6 +45,11 @@ const App = () => {
               <Route path="/calendar" element={
                 <ProtectedRoute>
                   <Calendar />
+                </ProtectedRoute>
+              } />
+              <Route path="/history" element={
+                <ProtectedRoute>
+                  <History />
                 </ProtectedRoute>
               } />
                 <Route path="/settings" element={

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft } from 'lucide-react';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+import { PulseButton } from '@/components/ui/pulse-button';
+
+interface Pulse {
+  id: string;
+  sender_id: string;
+  receiver_id: string;
+  created_at: string;
+}
+
+const History: React.FC = () => {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const [pulses, setPulses] = useState<Pulse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [historyEnabled, setHistoryEnabled] = useState(true);
+
+  useEffect(() => {
+    const enabled = localStorage.getItem('historyEnabled');
+    if (enabled !== null) {
+      setHistoryEnabled(enabled === 'true');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!user || !user.partnerId || !historyEnabled) {
+      setLoading(false);
+      return;
+    }
+
+    const fetchPulses = async () => {
+      const { data, error } = await supabase
+        .from('messages')
+        .select('id, sender_id, receiver_id, created_at')
+        .eq('type', 'pulse')
+        .or(`and(sender_id.eq.${user.id},receiver_id.eq.${user.partnerId}),and(sender_id.eq.${user.partnerId},receiver_id.eq.${user.id})`)
+        .order('created_at', { ascending: false });
+
+      if (!error && data) {
+        setPulses(data as Pulse[]);
+      } else {
+        console.error('Error fetching pulses:', error);
+      }
+      setLoading(false);
+    };
+
+    fetchPulses();
+  }, [user, historyEnabled]);
+
+  const now = new Date();
+  const monthlyCount = pulses.filter((p) => {
+    const date = new Date(p.created_at);
+    return date.getMonth() === now.getMonth() && date.getFullYear() === now.getFullYear();
+  }).length;
+
+  return (
+    <div className="min-h-screen bg-gradient-soft p-4">
+      <div className="max-w-4xl mx-auto">
+        <div className="mb-6">
+          <div className="flex items-center gap-4 mb-4">
+            <PulseButton
+              variant="ghost"
+              size="sm"
+              onClick={() => navigate('/dashboard')}
+            >
+              <ArrowLeft className="w-4 h-4" />
+            </PulseButton>
+            <div>
+              <h1 className="text-3xl font-serif font-bold text-foreground">History</h1>
+              <p className="text-muted-foreground">Your pulse history</p>
+            </div>
+          </div>
+        </div>
+
+        {!historyEnabled ? (
+          <p className="text-center text-muted-foreground">Historique vide</p>
+        ) : (
+          <div>
+            <div className="mb-4">
+              <h2 className="text-lg font-medium">Pulses this month: {monthlyCount}</h2>
+            </div>
+            {loading ? (
+              <p className="text-center text-muted-foreground">Loading...</p>
+            ) : pulses.length === 0 ? (
+              <p className="text-center text-muted-foreground">Historique vide</p>
+            ) : (
+              <ul className="space-y-2">
+                {pulses.map((pulse) => (
+                  <li
+                    key={pulse.id}
+                    className="p-3 bg-muted rounded-lg flex justify-between"
+                  >
+                    <span>
+                      {pulse.sender_id === user?.id
+                        ? 'You sent a pulse'
+                        : `${user?.partnerName || 'Partner'} sent a pulse`}
+                    </span>
+                    <span className="text-sm text-muted-foreground">
+                      {new Date(pulse.created_at).toLocaleString()}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default History;
+

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -32,6 +32,7 @@ interface SettingsData {
   email: string;
   bio: string;
   avatar: string;
+  historyEnabled: boolean;
   notifications: {
     pulses: boolean;
     messages: boolean;
@@ -55,6 +56,7 @@ const Settings: React.FC = () => {
     email: user?.email || '',
     bio: 'Living life with my amazing partner 💕',
     avatar: '',
+    historyEnabled: true,
     notifications: {
       pulses: true,
       messages: true,
@@ -70,6 +72,13 @@ const Settings: React.FC = () => {
   });
 
   const [activeSection, setActiveSection] = useState<'profile' | 'notifications' | 'privacy' | 'general'>('profile');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('historyEnabled');
+    if (stored !== null) {
+      setSettings((prev) => ({ ...prev, historyEnabled: stored === 'true' }));
+    }
+  }, []);
 
   useEffect(() => {
     const loadSettings = async () => {
@@ -398,6 +407,24 @@ const Settings: React.FC = () => {
               {activeSection === 'general' && (
                 <div className="space-y-6">
                   <div className="space-y-4">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <h3 className="font-medium">Pulse History</h3>
+                        <p className="text-sm text-muted-foreground">
+                          Save and display your pulse history
+                        </p>
+                      </div>
+                      <Switch
+                        checked={settings.historyEnabled}
+                        onCheckedChange={(checked) => {
+                          setSettings({ ...settings, historyEnabled: checked });
+                          localStorage.setItem('historyEnabled', String(checked));
+                        }}
+                      />
+                    </div>
+
+                    <Separator />
+
                     <div>
                       <h3 className="font-medium mb-3">Theme</h3>
                       <div className="grid grid-cols-3 gap-3">


### PR DESCRIPTION
## Summary
- add history page to list pulse messages and monthly count
- allow enabling/disabling pulse history in settings
- wire history route in app

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type in src/components/ui/textarea.tsx and @typescript-eslint/no-require-imports in tailwind.config.ts)*
- `npx eslint src/App.tsx src/pages/settings.tsx src/pages/history.tsx`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f86702f3c8331a4cfd719ae33316f