### PR TITLE
feat(calendar): half-hour grid with overlap highlighting

### DIFF
--- a/src/components/calendar/shared-calendar.tsx
+++ b/src/components/calendar/shared-calendar.tsx
@@ -50,6 +50,13 @@ export const SharedCalendar: React.FC<SharedCalendarProps> = ({ className }) => 
     return `${h}:${m}`;
   };
 
+  const snapToHalfHour = (time: string) => {
+    const mins = parseTime(time);
+    const snapped = Math.round(mins / 30) * 30;
+    const clamped = Math.min(Math.max(snapped, 0), 23 * 60 + 30);
+    return minutesToTime(clamped);
+  };
+
   const formatDisplay = (date: string, start: string, end: string) => {
     const dateObj = new Date(`${date}T${start}`);
     const today = new Date().toISOString().split('T')[0];
@@ -149,9 +156,11 @@ export const SharedCalendar: React.FC<SharedCalendarProps> = ({ className }) => 
 
   const addTimeSlot = async () => {
     if (!user) return;
-    const start = prompt('Start time (HH:MM)');
-    const end = prompt('End time (HH:MM)');
-    if (!start || !end) return;
+    const startInput = prompt('Start time (HH:MM)');
+    const endInput = prompt('End time (HH:MM)');
+    if (!startInput || !endInput) return;
+    const start = snapToHalfHour(startInput);
+    const end = snapToHalfHour(endInput);
     const title = prompt('Title') || null;
     const { data, error } = await supabase
       .from('time_slots')
@@ -165,9 +174,11 @@ export const SharedCalendar: React.FC<SharedCalendarProps> = ({ className }) => 
 
   const updateTimeSlot = async (id: string) => {
     if (!user) return;
-    const start = prompt('Start time (HH:MM)');
-    const end = prompt('End time (HH:MM)');
-    if (!start || !end) return;
+    const startInput = prompt('Start time (HH:MM)');
+    const endInput = prompt('End time (HH:MM)');
+    if (!startInput || !endInput) return;
+    const start = snapToHalfHour(startInput);
+    const end = snapToHalfHour(endInput);
     const title = prompt('Title') || null;
     const { data, error } = await supabase
       .from('time_slots')
@@ -279,6 +290,26 @@ export const SharedCalendar: React.FC<SharedCalendarProps> = ({ className }) => 
     return timeSlots.filter(slot => slot.date === date);
   };
 
+  const findOverlaps = (slots: TimeSlot[]) => {
+    const overlapping = new Set<string>();
+    for (let i = 0; i < slots.length; i++) {
+      for (let j = i + 1; j < slots.length; j++) {
+        const aStart = parseTime(slots[i].start);
+        const aEnd = parseTime(slots[i].end);
+        const bStart = parseTime(slots[j].start);
+        const bEnd = parseTime(slots[j].end);
+        if (aStart < bEnd && bStart < aEnd) {
+          overlapping.add(slots[i].id);
+          overlapping.add(slots[j].id);
+        }
+      }
+    }
+    return overlapping;
+  };
+  const slotsForSelectedDate = getSlotsForDate(selectedDate);
+  const overlappingSlots = findOverlaps(slotsForSelectedDate);
+  const halfHourMarks = Array.from({ length: 48 }, (_, i) => minutesToTime(i * 30));
+
   return (
     <Card className={cn("shadow-card animate-scale-in", className)}>
       <CardHeader>
@@ -355,56 +386,81 @@ export const SharedCalendar: React.FC<SharedCalendarProps> = ({ className }) => 
                 </PulseButton>
               </div>
 
-              {getSlotsForDate(selectedDate).length > 0 ? (
-                <div className="space-y-2">
-                  {getSlotsForDate(selectedDate).map((slot) => {
-                    const typeInfo = getSlotTypeInfo(slot.type);
-                    return (
-                      <div
-                        key={slot.id}
-                        className={cn(
-                          "p-3 rounded-lg border transition-all duration-200 hover:scale-[1.02]",
-                          typeInfo.color
-                        )}
-                      >
-                        <div className="flex items-center justify-between">
-                          <div className="flex items-center gap-2">
-                            {typeInfo.icon}
-                            <span className="font-medium">
-                              {slot.start} - {slot.end}
-                            </span>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <Badge variant="outline" className="text-xs">
-                              {typeInfo.label}
-                            </Badge>
-                            <button
-                              onClick={() => updateTimeSlot(slot.id)}
-                              className="p-1 hover:text-foreground text-muted-foreground"
-                            >
-                              <Pencil className="w-3 h-3" />
-                            </button>
-                            <button
-                              onClick={() => deleteTimeSlot(slot.id)}
-                              className="p-1 hover:text-destructive text-destructive/80"
-                            >
-                              <Trash2 className="w-3 h-3" />
-                            </button>
-                          </div>
+              <div className="relative border rounded-md overflow-hidden">
+                <div
+                  className="grid w-full"
+                  style={{ gridTemplateRows: 'repeat(48, 1.5rem)' }}
+                >
+                  {halfHourMarks.map((mark, i) => (
+                    <div
+                      key={mark}
+                      className="border-b border-border text-[10px] text-muted-foreground relative"
+                    >
+                      {i % 2 === 0 && (
+                        <span className="absolute -left-10">{mark}</span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+
+                {slotsForSelectedDate.map((slot) => {
+                  const typeInfo = getSlotTypeInfo(slot.type);
+                  const start = parseTime(slot.start);
+                  const end = parseTime(slot.end);
+                  const top = (start / (24 * 60)) * 100;
+                  const height = ((end - start) / (24 * 60)) * 100;
+                  const isOverlap = overlappingSlots.has(slot.id);
+                  return (
+                    <div
+                      key={slot.id}
+                      className={cn(
+                        'absolute left-0 right-0 m-0.5 p-2 rounded border text-xs flex flex-col justify-between',
+                        typeInfo.color,
+                        isOverlap && 'bg-destructive/20 border-destructive'
+                      )}
+                      style={{ top: `${top}%`, height: `${height}%` }}
+                    >
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          {typeInfo.icon}
+                          <span className="font-medium">
+                            {slot.start} - {slot.end}
+                          </span>
                         </div>
-                        {slot.title && (
-                          <p className="text-sm mt-1 opacity-90">{slot.title}</p>
-                        )}
+                        <div className="flex items-center gap-2">
+                          <Badge variant="outline" className="text-[10px]">
+                            {typeInfo.label}
+                          </Badge>
+                          <button
+                            onClick={() => updateTimeSlot(slot.id)}
+                            className="p-1 hover:text-foreground text-muted-foreground"
+                          >
+                            <Pencil className="w-3 h-3" />
+                          </button>
+                          <button
+                            onClick={() => deleteTimeSlot(slot.id)}
+                            className="p-1 hover:text-destructive text-destructive/80"
+                          >
+                            <Trash2 className="w-3 h-3" />
+                          </button>
+                        </div>
                       </div>
-                    );
-                  })}
-                </div>
-              ) : (
-                <div className="text-center py-8 text-muted-foreground">
-                  <Calendar className="w-8 h-8 mx-auto mb-2 opacity-50" />
-                  <p>No time slots for this day</p>
-                </div>
-              )}
+                      {slot.title && (
+                        <p className="text-[10px] mt-1 opacity-90">{slot.title}</p>
+                      )}
+                    </div>
+                  );
+                })}
+
+                {slotsForSelectedDate.length === 0 && (
+                  <div className="absolute inset-0 flex items-center justify-center text-muted-foreground">
+                    <div className="text-center">
+                      <Calendar className="w-8 h-8 mx-auto mb-2 opacity-50" />
+                      <p>No time slots for this day</p>
+                    </div>
+                  </div>
+                )}
+              </div>
             </div>
           </>
         ) : (


### PR DESCRIPTION
## Summary
- render week view in 30-minute rows
- snap added/edited slots to half-hour increments
- flag overlapping time blocks in calendar

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688f866e91948331a85c5c059726e29c