### PR TITLE
refactor: replace empty interfaces in command and textarea components

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {


### PR DESCRIPTION
## Summary
- replace empty `CommandDialogProps` interface with a type alias
- replace empty `TextareaProps` interface with a type alias

## Testing
- `npm run lint` *(fails: Parsing error in src/i18n.ts)*
- `npx eslint src/components/ui/command.tsx src/components/ui/textarea.tsx`


------
https://chatgpt.com/codex/tasks/task_e_688fd0066c508331803ee2a8f66b2b4a