### PR TITLE
chore: strengthen supabase typings for pairing and export

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -50,6 +50,8 @@ export type Database = {
           email: string
           id: string
           name: string
+          avatar_url: string | null
+          is_premium: boolean | null
           partner_id: string | null
           snooze_until: string | null
           use_face_id: boolean | null
@@ -61,6 +63,8 @@ export type Database = {
           email: string
           id?: string
           name: string
+          avatar_url?: string | null
+          is_premium?: boolean | null
           partner_id?: string | null
           snooze_until?: string | null
           use_face_id?: boolean | null
@@ -72,6 +76,8 @@ export type Database = {
           email?: string
           id?: string
           name?: string
+          avatar_url?: string | null
+          is_premium?: boolean | null
           partner_id?: string | null
           snooze_until?: string | null
           use_face_id?: boolean | null
@@ -112,6 +118,30 @@ export type Database = {
           id?: string
           p256dh?: string
           user_id?: string
+        }
+        Relationships: []
+      },
+      reminders: {
+        Row: {
+          id: string
+          user_id: string
+          time_slot_id: string
+          remind_at: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          time_slot_id: string
+          remind_at: string
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          time_slot_id?: string
+          remind_at?: string
+          created_at?: string
         }
         Relationships: []
       },

--- a/src/lib/reminders.ts
+++ b/src/lib/reminders.ts
@@ -9,8 +9,7 @@ interface ReminderSlot {
 export const scheduleReminder = async (userId: string, slot: ReminderSlot) => {
   const slotTime = new Date(`${slot.date}T${slot.start}`);
   const remindAt = new Date(slotTime.getTime() - 2 * 60 * 60 * 1000);
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  await (supabase.from as any)('reminders').insert({
+  await supabase.from('reminders').insert({
     user_id: userId,
     time_slot_id: slot.id,
     remind_at: remindAt.toISOString(),

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -280,6 +280,10 @@ codex/add-export-data-feature-in-settings
         profile: profileRes.data,
         messages: messagesRes.data,
         time_slots: timeSlotsRes.data,
+      } as {
+        profile: Tables<'profiles'> | null;
+        messages: Tables<'messages'>[];
+        time_slots: Tables<'time_slots'>[];
       };
 
       const jsonBlob = new Blob([JSON.stringify(exportData, null, 2)], {
@@ -291,7 +295,7 @@ codex/add-export-data-feature-in-settings
       jsonLink.download = 'pulse-data.json';
       jsonLink.click();
 
-      const convertToCsv = (items: any[]) => {
+      const convertToCsv = <T extends Record<string, unknown>>(items: T[]) => {
         if (!items || items.length === 0) return '';
         const headers = Object.keys(items[0]);
         const rows = items.map((row) =>
@@ -303,15 +307,15 @@ codex/add-export-data-feature-in-settings
       const csvSections: string[] = [];
       if (exportData.profile) {
         csvSections.push('Profiles');
-        csvSections.push(convertToCsv([exportData.profile] as any));
+        csvSections.push(convertToCsv([exportData.profile]));
       }
       if (exportData.messages) {
         csvSections.push('Messages');
-        csvSections.push(convertToCsv(exportData.messages as any));
+        csvSections.push(convertToCsv(exportData.messages));
       }
       if (exportData.time_slots) {
         csvSections.push('Time Slots');
-        csvSections.push(convertToCsv(exportData.time_slots as any));
+        csvSections.push(convertToCsv(exportData.time_slots));
       }
 
       const csvBlob = new Blob([csvSections.join('\n\n')], {


### PR DESCRIPTION
## Summary
- add explicit profile and avatar types for pairing and polling queries
- type data export helper to remove `any`
- extend Supabase schema with avatar, premium, and reminders table definitions

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error: ',' expected in src/i18n.ts and others)*

------
https://chatgpt.com/codex/tasks/task_e_688fd0053e688331be1d0abda289a3ca