### PR TITLE
chore: clean translation placeholders

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -6,30 +6,18 @@ const translations = {
     createAccount: 'Create account',
     joinPartner: 'Join partner',
     invitePartner: 'Invite partner',
- codex/handle-absent-user.partnerid-in-dashboard
     notLinked: 'Not linked to a partner',
-
- codex/add-face-id-switch-in-settings
     useFaceID: 'Use Face ID',
-
     autoDelete30d: 'Auto delete messages after 30 days',
- main
- main
   },
   fr: {
     addFirstAvailability: 'Ajoutez votre première disponibilité',
     createAccount: 'Créer un compte',
     joinPartner: 'Rejoindre mon/ma partenaire',
     invitePartner: 'Inviter mon/ma partenaire',
- codex/handle-absent-user.partnerid-in-dashboard
     notLinked: 'Pas de partenaire lié',
-
- codex/add-face-id-switch-in-settings
     useFaceID: 'Utiliser Face ID',
-
     autoDelete30d: 'Supprimer automatiquement les messages après 30 jours',
- main
- main
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- remove placeholder codex and main lines from translations
- ensure English and French translation keys match

## Testing
- `node <... script ...>`
- `npm run lint` *(fails: Parsing error in src/App.tsx)*
- `npx eslint src/i18n.ts`


------
https://chatgpt.com/codex/tasks/task_e_688fd00275608331823362be050ef4d9