### PR TITLE
feat: switch primary palette to rose–coral gradient

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -17,11 +17,11 @@
     --popover: 220 20% 97%;
     --popover-foreground: 220 10% 15%;
 
-    /* Primary: Sophisticated Blue */
-    --primary: 220 60% 55%;
+    /* Primary: Rose to Coral Gradient */
+    --primary: 346 86% 58%;
     --primary-foreground: 220 15% 98%;
     --primary-soft: 220 30% 85%;
-    --primary-glow: 220 60% 65%;
+    --primary-glow: 16 100% 66%;
 
     /* Secondary: Neutral Gray */
     --secondary: 220 15% 88%;
@@ -58,7 +58,7 @@
 
     /* Shadows */
     --shadow-soft: 0 4px 20px hsl(var(--primary) / 0.1);
-    --shadow-glow: 0 0 30px hsl(var(--primary-glow) / 0.3);
+    --shadow-glow: 0 0 30px hsla(0, 0%, 100%, 0.5);
     --shadow-card: 0 8px 32px hsl(var(--primary) / 0.08);
 
     /* Border Radius */
@@ -94,10 +94,10 @@
     --popover: 220 20% 12%;
     --popover-foreground: 220 10% 95%;
 
-    --primary: 220 60% 55%;
+    --primary: 346 86% 58%;
     --primary-foreground: 220 15% 8%;
     --primary-soft: 220 30% 25%;
-    --primary-glow: 220 60% 65%;
+    --primary-glow: 16 100% 66%;
 
     --secondary: 220 15% 20%;
     --secondary-foreground: 220 10% 95%;
@@ -126,7 +126,7 @@
     --gradient-card: linear-gradient(145deg, hsl(var(--card)), hsl(var(--primary-soft) / 0.2));
 
     --shadow-soft: 0 4px 20px hsl(0 0% 0% / 0.3);
-    --shadow-glow: 0 0 30px hsl(var(--primary-glow) / 0.4);
+    --shadow-glow: 0 0 30px hsla(0, 0%, 100%, 0.4);
     --shadow-card: 0 8px 32px hsl(0 0% 0% / 0.4);
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -68,11 +68,11 @@ export default {
 					offline: 'hsl(var(--pulse-offline))'
 				}
 			},
-			backgroundImage: {
-				'gradient-primary': 'var(--gradient-primary)',
-				'gradient-soft': 'var(--gradient-soft)',
-				'gradient-card': 'var(--gradient-card)'
-			},
+                        backgroundImage: {
+                                'gradient-primary': 'linear-gradient(135deg, hsl(var(--primary)), hsl(var(--primary-glow)))',
+                                'gradient-soft': 'var(--gradient-soft)',
+                                'gradient-card': 'var(--gradient-card)'
+                        },
 			boxShadow: {
 				'soft': 'var(--shadow-soft)',
 				'glow': 'var(--shadow-glow)',


### PR DESCRIPTION
## Summary
- redefined primary palette variables to rose→coral gradient
- switched glow halo to semi‑transparent white and updated Tailwind gradient mapping

## Testing
- `npm run lint` (fails: Parsing error, `require()` import)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689086babf188331b680ec8dd697a04b