### PR TITLE
Add progress indicator for upcoming calendar slots

### DIFF
--- a/src/components/calendar/shared-calendar.tsx
+++ b/src/components/calendar/shared-calendar.tsx
@@ -16,6 +16,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
 import { scheduleReminder } from "@/lib/reminders";
 import { useTranslation } from "@/i18n";
+import { ProgressRing } from "@/components/ui/progress-ring";
 
 interface TimeSlot {
   id: string;
@@ -51,6 +52,12 @@ export const SharedCalendar: React.FC<SharedCalendarProps> = ({
   const [selectedDate, setSelectedDate] = useState("2024-01-15");
   const [view, setView] = useState<"week" | "suggestions">("week");
   const [showMutualOnly, setShowMutualOnly] = useState(false);
+  const [now, setNow] = useState(new Date());
+
+  useEffect(() => {
+    const interval = setInterval(() => setNow(new Date()), 60000);
+    return () => clearInterval(interval);
+  }, []);
 
   const parseTime = (time: string) => {
     const [h, m] = time.split(":").map(Number);
@@ -354,17 +361,10 @@ export const SharedCalendar: React.FC<SharedCalendarProps> = ({
   };
   const slotsForSelectedDate = getSlotsForDate(selectedDate);
   const overlappingSlots = findOverlaps(slotsForSelectedDate);
- codex/remove-codex-lines-and-main-tokens
-  const halfHourMarks = Array.from({ length: 48 }, (_, i) =>
-    minutesToTime(i * 30),
-  );
 
- codex/refactor-routes-and-clean-up-imports
 
 
   const halfHourMarks = Array.from({ length: 48 }, (_, i) => minutesToTime(i * 30));
- main
- main
   const allSlotsForSelectedDate = timeSlots.filter(
     (slot) => slot.date === selectedDate,
   );
@@ -479,6 +479,12 @@ export const SharedCalendar: React.FC<SharedCalendarProps> = ({
                   const top = (start / (24 * 60)) * 100;
                   const height = ((end - start) / (24 * 60)) * 100;
                   const isOverlap = overlappingSlots.has(slot.id);
+                  const slotStartDate = new Date(`${slot.date}T${slot.start}`);
+                  const diff =
+                    (slotStartDate.getTime() - now.getTime()) / 60000;
+                  const isUpcoming = diff <= 120 && diff >= 0;
+                  const progress =
+                    ((120 - Math.min(120, Math.max(0, diff))) / 120) * 100;
                   return (
                     <div
                       key={slot.id}
@@ -491,6 +497,9 @@ export const SharedCalendar: React.FC<SharedCalendarProps> = ({
                     >
                       <div className="flex items-center justify-between">
                         <div className="flex items-center gap-2">
+                          {isUpcoming && (
+                            <ProgressRing progress={progress} size={16} />
+                          )}
                           {typeInfo.icon}
                           <span className="font-medium">
                             {slot.start} - {slot.end}
@@ -512,7 +521,6 @@ export const SharedCalendar: React.FC<SharedCalendarProps> = ({
                           >
                             <Trash2 className="w-3 h-3" />
                           </button>
- codex/refactor-routes-and-clean-up-imports
 
                         </div>
                       </div>
@@ -534,6 +542,12 @@ export const SharedCalendar: React.FC<SharedCalendarProps> = ({
                 <div className="space-y-2">
                   {slotsForSelectedDate.map((slot) => {
                     const typeInfo = getSlotTypeInfo(slot.type);
+                    const slotStartDate = new Date(`${slot.date}T${slot.start}`);
+                    const diff =
+                      (slotStartDate.getTime() - now.getTime()) / 60000;
+                    const isUpcoming = diff <= 120 && diff >= 0;
+                    const progress =
+                      ((120 - Math.min(120, Math.max(0, diff))) / 120) * 100;
                     return (
                       <div
                         key={slot.id}
@@ -544,6 +558,9 @@ export const SharedCalendar: React.FC<SharedCalendarProps> = ({
                       >
                         <div className="flex items-center justify-between">
                           <div className="flex items-center gap-2">
+                            {isUpcoming && (
+                              <ProgressRing progress={progress} size={16} />
+                            )}
                             {typeInfo.icon}
                             <span className="font-medium">
                               {slot.start} - {slot.end}
@@ -566,7 +583,6 @@ export const SharedCalendar: React.FC<SharedCalendarProps> = ({
                               <Trash2 className="w-3 h-3" />
                             </button>
                           </div>
- main
                         </div>
                         {slot.title && (
                           <p className="text-[10px] mt-1 opacity-90">
@@ -574,17 +590,8 @@ export const SharedCalendar: React.FC<SharedCalendarProps> = ({
                           </p>
                         )}
                       </div>
- codex/refactor-routes-and-clean-up-imports
-
- codex/remove-codex-lines-and-main-tokens
-
-                      {slot.title && (
-                        <p className="text-[10px] mt-1 opacity-90">{slot.title}</p>
-                      )}
- main
-                    </div>
-                  );
-                })}
+                    );
+                  })}
 
                 {slotsForSelectedDate.length === 0 && (
                   <div className="absolute inset-0 flex items-center justify-center text-muted-foreground">
@@ -595,13 +602,6 @@ export const SharedCalendar: React.FC<SharedCalendarProps> = ({
                   </div>
                 )}
               </div>
- codex/refactor-routes-and-clean-up-imports
-
-
- main
-                    );
-                  })}
-                </div>
               ) : (
                 <div className="text-center py-8 text-muted-foreground">
                   <svg
@@ -626,7 +626,6 @@ export const SharedCalendar: React.FC<SharedCalendarProps> = ({
                   </p>
                 </div>
               )}
- main
             </div>
           </>
         ) : (

--- a/src/components/ui/progress-ring.tsx
+++ b/src/components/ui/progress-ring.tsx
@@ -1,0 +1,60 @@
+import React from "react"
+import { cn } from "@/lib/utils"
+
+interface ProgressRingProps extends React.SVGProps<SVGSVGElement> {
+  progress: number
+  size?: number
+  strokeWidth?: number
+}
+
+const ProgressRing: React.FC<ProgressRingProps> = ({
+  progress,
+  size = 24,
+  strokeWidth = 4,
+  className,
+  ...props
+}) => {
+  const radius = (size - strokeWidth) / 2
+  const circumference = 2 * Math.PI * radius
+  const offset = circumference - (progress / 100) * circumference
+  const gradientId = React.useId()
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      className={cn("rotate-[-90deg]", className)}
+      {...props}
+    >
+      <defs>
+        <linearGradient id={gradientId} x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="hsl(var(--primary))" />
+          <stop offset="100%" stopColor="hsl(var(--primary-glow))" />
+        </linearGradient>
+      </defs>
+      <circle
+        stroke="hsl(var(--muted))"
+        strokeWidth={strokeWidth}
+        fill="transparent"
+        r={radius}
+        cx={size / 2}
+        cy={size / 2}
+      />
+      <circle
+        stroke={`url(#${gradientId})`}
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        fill="transparent"
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        r={radius}
+        cx={size / 2}
+        cy={size / 2}
+        className="drop-shadow-[0_0_4px_hsl(var(--primary-glow)/0.5)] transition-all"
+      />
+    </svg>
+  )
+}
+
+export { ProgressRing }
+


### PR DESCRIPTION
## Summary
- add reusable `ProgressRing` svg component using Pulse gradient
- show ring on calendar events starting within 120 minutes and refresh every minute
- tidy up leftover artifacts in calendar component

## Testing
- `npm run lint` *(fails: Parsing error: ',' expected in src/i18n.ts; Parsing error: ')' expected in src/pages/settings.tsx; A `require()` style import is forbidden in tailwind.config.ts)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689086c71e748331a50dadc721a199e3