### PR TITLE
Add pulse sent toast and translation

### DIFF
--- a/src/components/dashboard/central-pulse-button.tsx
+++ b/src/components/dashboard/central-pulse-button.tsx
@@ -3,6 +3,7 @@ import { Heart, Check } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/hooks/use-toast';
+import { useTranslation } from '@/i18n';
 import { cn } from '@/lib/utils';
 
 interface CentralPulseButtonProps {
@@ -15,6 +16,7 @@ export const CentralPulseButton: React.FC<CentralPulseButtonProps> = ({ classNam
   const { user } = useAuth();
   const [state, setState] = useState<PulseState>('idle');
   const { toast } = useToast();
+  const { t } = useTranslation();
 
   const handleClick = async () => {
     if (!user || !user.partnerId) return;
@@ -84,6 +86,7 @@ export const CentralPulseButton: React.FC<CentralPulseButtonProps> = ({ classNam
         content: 'pulse',
         type: 'pulse'
       });
+      toast({ description: t('sent') });
       setState('sent');
     } catch (error) {
       console.error('Error sending pulse:', error);

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -6,7 +6,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 1000
 
 type ToasterToast = ToastProps & {
   id: string

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -7,12 +7,9 @@ const translations = {
     joinPartner: 'Join partner',
     invitePartner: 'Invite partner',
     notLinked: 'Not linked to a partner',
- codex/refactor-routes-and-clean-up-imports
-
-
- main
     useFaceID: 'Use Face ID',
     autoDelete30d: 'Auto delete messages after 30 days',
+    sent: 'Pulse sent!',
   },
   fr: {
     addFirstAvailability: 'Ajoutez votre première disponibilité',
@@ -20,12 +17,9 @@ const translations = {
     joinPartner: 'Rejoindre mon/ma partenaire',
     invitePartner: 'Inviter mon/ma partenaire',
     notLinked: 'Pas de partenaire lié',
- codex/refactor-routes-and-clean-up-imports
-
-
- main
     useFaceID: 'Utiliser Face ID',
     autoDelete30d: 'Supprimer automatiquement les messages après 30 jours',
+    sent: 'Pulse envoyé !',
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- shorten toast auto-remove delay
- show a sent toast after dispatching a pulse
- translate new "sent" message in English and French

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error in src/pages/settings.tsx; A `require()` style import is forbidden in tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689086cb7838833188181ba1d42e5f6a