### PR TITLE
Add translation glossary and reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,7 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## Translation Glossary
+
+Please refer to the [Translation Glossary](docs/translation-glossary.md) for agreed terms, tone guidelines, and forbidden vocabulary when contributing translations.

--- a/docs/translation-glossary.md
+++ b/docs/translation-glossary.md
@@ -1,0 +1,27 @@
+# Translation Glossary
+
+This glossary aligns the project's French translations and tone.
+
+## Agreed Terms
+
+| English | French |
+| --- | --- |
+| Pulse | Pulse |
+| Ready | Disponible |
+| Busy | Occupé·e |
+
+## Tone Guidelines
+
+- Use a warm and friendly tone.
+- Keep language inclusive and gender-neutral.
+- Use the informal "tu" and gender-neutral forms (e.g., using midpoints or "iel" when a pronoun is needed).
+
+## Forbidden Terms and Alternatives
+
+Avoid explicit terms. Use the suggested neutral alternatives instead.
+
+| Forbidden Term | Preferred Alternative |
+| --- | --- |
+| sexe | sexualité |
+| rapports | relations intimes |
+


### PR DESCRIPTION
## Summary
- add translation glossary documenting agreed terms, tone guidelines, and forbidden vocabulary
- link translation glossary from README for contributors

## Testing
- `npm test` *(fails: JSON.parse Invalid package.json)*
- `npm run lint` *(fails: JSON.parse Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890d5af8a708331a3111bd84683022e