### PR TITLE
feat: add translatable status labels

### DIFF
--- a/src/components/dashboard/pulse-status.tsx
+++ b/src/components/dashboard/pulse-status.tsx
@@ -5,6 +5,7 @@ import { StatusIndicator } from '@/components/ui/status-indicator';
 import { Heart, Moon, Coffee, Sparkles } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { SnoozeToggle } from './snooze-toggle';
+import { useTranslation } from '@/i18n';
 
 type PulseStatus = 'active' | 'away' | 'offline';
 
@@ -15,25 +16,26 @@ interface PulseStatusProps {
 export const PulseStatusCard: React.FC<PulseStatusProps> = ({ className }) => {
   const [myStatus, setMyStatus] = useState<PulseStatus>('offline');
   const [partnerStatus] = useState<PulseStatus>('active');
+  const { t } = useTranslation();
 
   const statusOptions = [
-    { 
-      status: 'active' as PulseStatus, 
-      icon: Heart, 
-      label: 'Ready', 
-      description: 'Available for connection'
+    {
+      status: 'active' as PulseStatus,
+      icon: Heart,
+      label: t('statusReadyLabel'),
+      description: t('statusReadyDescription')
     },
-    { 
-      status: 'away' as PulseStatus, 
-      icon: Coffee, 
-      label: 'Busy', 
-      description: 'Maybe later'
+    {
+      status: 'away' as PulseStatus,
+      icon: Coffee,
+      label: t('statusBusyLabel'),
+      description: t('statusBusyDescription')
     },
-    { 
-      status: 'offline' as PulseStatus, 
-      icon: Moon, 
-      label: 'Not Available', 
-      description: 'Do not disturb'
+    {
+      status: 'offline' as PulseStatus,
+      icon: Moon,
+      label: t('statusNotAvailableLabel'),
+      description: t('statusNotAvailableDescription')
     }
   ];
 

--- a/src/components/ui/status-indicator.tsx
+++ b/src/components/ui/status-indicator.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { cn } from '@/lib/utils';
 import { cva, type VariantProps } from 'class-variance-authority';
+import { useTranslation } from '@/i18n';
 
 const statusIndicatorVariants = cva(
   "inline-flex items-center gap-2 font-medium transition-all duration-300",
@@ -55,13 +56,18 @@ export interface StatusIndicatorProps
 
 const StatusIndicator = React.forwardRef<HTMLDivElement, StatusIndicatorProps>(
   ({ className, status, size, label, showPulse = true, ...props }, ref) => {
+    const { t } = useTranslation();
     const getStatusLabel = () => {
       if (label) return label;
       switch (status) {
-        case 'active': return 'Ready';
-        case 'away': return 'Away';
-        case 'offline': return 'Offline';
-        default: return 'Unknown';
+        case 'active':
+          return t('statusReadyLabel');
+        case 'away':
+          return t('statusBusyLabel');
+        case 'offline':
+          return t('statusNotAvailableLabel');
+        default:
+          return '';
       }
     };
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -10,6 +10,12 @@ const translations = {
     useFaceID: 'Use Face ID',
     autoDelete30d: 'Auto delete messages after 30 days',
     sent: 'Pulse sent!',
+    statusReadyLabel: 'Ready',
+    statusReadyDescription: 'Available for connection',
+    statusBusyLabel: 'Busy',
+    statusBusyDescription: 'Catch you later',
+    statusNotAvailableLabel: 'Not Available',
+    statusNotAvailableDescription: 'Need a moment',
   },
   fr: {
     addFirstAvailability: 'Ajoutez votre première disponibilité',
@@ -20,6 +26,12 @@ const translations = {
     useFaceID: 'Utiliser Face ID',
     autoDelete30d: 'Supprimer automatiquement les messages après 30 jours',
     sent: 'Pulse envoyé !',
+    statusReadyLabel: 'Prêt',
+    statusReadyDescription: 'Disponible pour se connecter',
+    statusBusyLabel: 'Occupé',
+    statusBusyDescription: 'À plus tard',
+    statusNotAvailableLabel: 'Indisponible',
+    statusNotAvailableDescription: "Besoin d'un moment",
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- add i18n keys for status labels and descriptions
- wire status components to use translations
- soften status descriptions with empathetic phrasing

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890d5abfe548331bd0540f349fb6ec0