### PR TITLE
feat: localize later-thanks message

### DIFF
--- a/src/components/dashboard/central-pulse-button.tsx
+++ b/src/components/dashboard/central-pulse-button.tsx
@@ -41,7 +41,7 @@ export const CentralPulseButton: React.FC<CentralPulseButtonProps> = ({ classNam
     const partnerStatus = (user as unknown as { partnerStatus?: string })?.partnerStatus;
     if (partnerStatus === 'away' || partnerStatus === 'offline') {
       toast({
-        description: 'Merci, on se retrouve plus tard !',
+        description: t('laterThanks'),
       });
       return;
     }
@@ -54,7 +54,7 @@ export const CentralPulseButton: React.FC<CentralPulseButtonProps> = ({ classNam
         .maybeSingle();
 
       if (!statusError && (profile?.status === 'away' || profile?.status === 'offline')) {
-        toast({ description: 'Merci, on se retrouve plus tard !' });
+        toast({ description: t('laterThanks') });
         return;
       }
 
@@ -68,7 +68,7 @@ export const CentralPulseButton: React.FC<CentralPulseButtonProps> = ({ classNam
         .maybeSingle();
 
       if (!messageError && lastMessage?.content === '⏰ Pas dispo') {
-        toast({ description: 'Merci, on se retrouve plus tard !' });
+        toast({ description: t('laterThanks') });
         return;
       }
     } catch (err) {

--- a/src/components/messaging/message-center.tsx
+++ b/src/components/messaging/message-center.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
+import { useTranslation } from '@/i18n';
 
 interface Message {
   id: string;
@@ -38,6 +39,7 @@ interface MessageCenterProps {
 export const MessageCenter: React.FC<MessageCenterProps> = ({ className }) => {
   const { user } = useAuth();
   const { toast } = useToast();
+  const { t } = useTranslation();
   const [messages, setMessages] = useState<Message[]>([]);
   const [newMessage, setNewMessage] = useState('');
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
@@ -213,7 +215,7 @@ export const MessageCenter: React.FC<MessageCenterProps> = ({ className }) => {
     if (partnerStatus === 'away' || partnerStatus === 'offline') {
       const feedback: Message = {
         id: `local-${Date.now()}`,
-        content: 'Merci, on se retrouve plus tard !',
+        content: t('laterThanks'),
         type: 'text',
         sender_id: user.id,
         receiver_id: user.partnerId,
@@ -222,7 +224,7 @@ export const MessageCenter: React.FC<MessageCenterProps> = ({ className }) => {
         sender_name: user.name,
       };
       setMessages(prev => [...prev, feedback]);
-      toast({ description: 'Merci, on se retrouve plus tard !' });
+      toast({ description: t('laterThanks') });
       return;
     }
 
@@ -236,7 +238,7 @@ export const MessageCenter: React.FC<MessageCenterProps> = ({ className }) => {
       if (!statusError && (profile?.status === 'away' || profile?.status === 'offline')) {
         const feedback: Message = {
           id: `local-${Date.now()}`,
-          content: 'Merci, on se retrouve plus tard !',
+          content: t('laterThanks'),
           type: 'text',
           sender_id: user.id,
           receiver_id: user.partnerId,
@@ -245,7 +247,7 @@ export const MessageCenter: React.FC<MessageCenterProps> = ({ className }) => {
           sender_name: user.name,
         };
         setMessages(prev => [...prev, feedback]);
-        toast({ description: 'Merci, on se retrouve plus tard !' });
+        toast({ description: t('laterThanks') });
         return;
       }
 
@@ -261,7 +263,7 @@ export const MessageCenter: React.FC<MessageCenterProps> = ({ className }) => {
       if (!messageError && lastMessage?.content === '⏰ Pas dispo') {
         const feedback: Message = {
           id: `local-${Date.now()}`,
-          content: 'Merci, on se retrouve plus tard !',
+          content: t('laterThanks'),
           type: 'text',
           sender_id: user.id,
           receiver_id: user.partnerId,
@@ -270,7 +272,7 @@ export const MessageCenter: React.FC<MessageCenterProps> = ({ className }) => {
           sender_name: user.name,
         };
         setMessages(prev => [...prev, feedback]);
-        toast({ description: 'Merci, on se retrouve plus tard !' });
+        toast({ description: t('laterThanks') });
         return;
       }
     } catch (err) {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -10,6 +10,7 @@ const translations = {
     useFaceID: 'Use Face ID',
     autoDelete30d: 'Auto delete messages after 30 days',
     sent: 'Pulse sent!',
+    laterThanks: 'Thanks for letting us know. We\'ll check back later!',
   },
   fr: {
     addFirstAvailability: 'Ajoutez votre première disponibilité',
@@ -20,6 +21,7 @@ const translations = {
     useFaceID: 'Utiliser Face ID',
     autoDelete30d: 'Supprimer automatiquement les messages après 30 jours',
     sent: 'Pulse envoyé !',
+    laterThanks: 'Merci de nous l\'avoir signalé ! On se retrouve plus tard !',
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- add `laterThanks` i18n key in English and French
- replace hard-coded refusal text in central pulse button and message center with `t('laterThanks')`

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890d5adb6d08331978d1259b839ebab