### PR TITLE
fix settings error handling

### DIFF
--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -181,16 +181,6 @@ const Settings: React.FC = () => {
       toast({ description: 'Failed to save settings' });
     } else {
       toast({ description: 'Settings saved' });
-
-    if (error) {
-      console.error('Error saving settings:', error);
-      toast({
-        title: 'Save failed',
-        description: 'Could not update settings.',
-        variant: 'destructive',
-      });
-    } else {
-      toast({ title: 'Settings saved', description: 'Your changes have been saved.' });
     }
   };
 


### PR DESCRIPTION
## Summary
- close dangling else block in settings page
- consolidate duplicate error handling for saving settings

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890da6054dc8331bbf97ba057723040