### PR TITLE
refactor auth context to use service

### DIFF
--- a/src/components/auth/auth-card.tsx
+++ b/src/components/auth/auth-card.tsx
@@ -26,7 +26,7 @@ export const AuthCard: React.FC<AuthCardProps> = ({ mode, onModeChange, classNam
     partnerEmail: ''
   });
   
-  const { login, register, connectPartner, user } = useAuth();
+  const { signIn, signUp, connectPartner, user } = useAuth();
   const navigate = useNavigate();
   const { toast } = useToast();
   
@@ -65,14 +65,14 @@ export const AuthCard: React.FC<AuthCardProps> = ({ mode, onModeChange, classNam
       
       switch (mode) {
         case 'login':
-          success = await login(formData.email, formData.password);
+          success = await signIn(formData.email, formData.password);
           break;
         case 'register':
           if (formData.password !== formData.confirmPassword) {
             alert('Passwords do not match');
             return;
           }
-          success = await register(formData.name, formData.email, formData.password);
+          success = await signUp(formData.name, formData.email, formData.password);
           break;
         case 'connect':
           success = await connectPartner(formData.partnerEmail);

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,114 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export const signIn = (email: string, password: string) => {
+  return supabase.auth.signInWithPassword({ email, password });
+};
+
+export const signUp = (name: string, email: string, password: string) => {
+  const redirectUrl = `${window.location.origin}/`;
+  return supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      emailRedirectTo: redirectUrl,
+      data: { name }
+    }
+  });
+};
+
+export const signOut = () => supabase.auth.signOut();
+
+export const getProfile = (userId: string) => {
+  return supabase
+    .from('profiles')
+    .select(`
+      *,
+      partner:partner_id(name, snooze_until)
+    `)
+    .eq('user_id', userId)
+    .single();
+};
+
+export const connectPartner = async (partnerEmail: string, currentUserId: string) => {
+  const { data: partnerProfile, error: findError } = await supabase
+    .from('profiles')
+    .select('id, user_id, name')
+    .eq('email', partnerEmail)
+    .single();
+
+  if (findError || !partnerProfile) {
+    return { error: 'Partner not found. Please check the email address.' };
+  }
+
+  const { data: currentProfile, error: currentProfileError } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('user_id', currentUserId)
+    .single();
+
+  if (currentProfileError || !currentProfile) {
+    return { error: 'Unable to retrieve your profile.' };
+  }
+
+  const { error: updateError } = await supabase
+    .from('profiles')
+    .update({ partner_id: partnerProfile.id })
+    .eq('user_id', currentUserId);
+
+  if (updateError) {
+    return { error: 'Unable to connect with partner. Please try again.' };
+  }
+
+  const { error: partnerUpdateError } = await supabase
+    .from('profiles')
+    .update({ partner_id: currentProfile.id })
+    .eq('user_id', partnerProfile.user_id);
+
+  if (partnerUpdateError) {
+    return { error: 'Unable to connect with partner. Please try again.' };
+  }
+
+  return { data: partnerProfile };
+};
+
+export const connectByCode = async (code: string, currentUserId: string) => {
+  const { data: partnerProfile, error: findError } = await supabase
+    .from('profiles')
+    .select('id, user_id, name')
+    .like('id', `${code}%`)
+    .single();
+
+  if (findError || !partnerProfile) {
+    return { error: 'Partner not found. Please check the code.' };
+  }
+
+  const { data: currentProfile, error: currentProfileError } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('user_id', currentUserId)
+    .single();
+
+  if (currentProfileError || !currentProfile) {
+    return { error: 'Unable to retrieve your profile.' };
+  }
+
+  const { error: updateError } = await supabase
+    .from('profiles')
+    .update({ partner_id: partnerProfile.id })
+    .eq('user_id', currentUserId);
+
+  if (updateError) {
+    return { error: 'Unable to connect with partner. Please try again.' };
+  }
+
+  const { error: partnerUpdateError } = await supabase
+    .from('profiles')
+    .update({ partner_id: currentProfile.id })
+    .eq('user_id', partnerProfile.user_id);
+
+  if (partnerUpdateError) {
+    return { error: 'Unable to connect with partner. Please try again.' };
+  }
+
+  return { data: partnerProfile };
+};


### PR DESCRIPTION
## Summary
- create auth service wrapping Supabase sign-in, sign-up and partner link operations
- refactor AuthContext to consume new service and expose signIn/signUp
- update AuthCard to use new context functions

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890e5d1a2708331bb7e46bfe1650e0c