### PR TITLE
Validate partner pairing and add integration tests

### DIFF
--- a/src/services/auth.test.ts
+++ b/src/services/auth.test.ts
@@ -1,10 +1,71 @@
-import { signIn } from './auth';
+import { signIn, connectPartner } from './auth';
 import { supabase } from '@/integrations/supabase/client';
+import { vi } from 'vitest';
 
 test('signIn calls supabase auth method', async () => {
   await signIn('test@example.com', 'password');
   expect(supabase.auth.signInWithPassword).toHaveBeenCalledWith({
     email: 'test@example.com',
     password: 'password',
+  });
+});
+
+describe('partner connections', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const qb: any = supabase.from('profiles');
+    qb.single.mockReset();
+    qb.update.mockReset();
+  });
+
+  test('prevents self pairing', async () => {
+    const qb: any = supabase.from('profiles');
+    qb.single
+      .mockResolvedValueOnce({
+        data: { id: 1, user_id: 'user1', name: 'User1', partner_id: null },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { id: 1, partner_id: null },
+        error: null,
+      });
+
+    const result = await connectPartner('self@example.com', 'user1');
+    expect(result).toEqual({ error: 'Cannot connect with yourself.' });
+    expect(qb.update).not.toHaveBeenCalled();
+  });
+
+  test('prevents double pairing when current user already paired', async () => {
+    const qb: any = supabase.from('profiles');
+    qb.single
+      .mockResolvedValueOnce({
+        data: { id: 2, user_id: 'user2', name: 'User2', partner_id: null },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { id: 1, partner_id: 99 },
+        error: null,
+      });
+
+    const result = await connectPartner('partner@example.com', 'user1');
+    expect(result).toEqual({ error: 'User already paired' });
+    expect(qb.update).not.toHaveBeenCalled();
+  });
+
+  test('prevents double pairing when partner already paired', async () => {
+    const qb: any = supabase.from('profiles');
+    qb.single
+      .mockResolvedValueOnce({
+        data: { id: 2, user_id: 'user2', name: 'User2', partner_id: 99 },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { id: 1, partner_id: null },
+        error: null,
+      });
+
+    const result = await connectPartner('partner@example.com', 'user1');
+    expect(result).toEqual({ error: 'User already paired' });
+    expect(qb.update).not.toHaveBeenCalled();
   });
 });

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -41,7 +41,7 @@ export const connectPartner = async (
   const { data: partnerProfile, error: findError } = await withRetry(() =>
     supabase
       .from('profiles')
-      .select('id, user_id, name')
+      .select('id, user_id, name, partner_id')
       .eq('email', partnerEmail)
       .single()
   );
@@ -53,13 +53,24 @@ export const connectPartner = async (
   const { data: currentProfile, error: currentProfileError } = await withRetry(() =>
     supabase
       .from('profiles')
-      .select('id')
+      .select('id, partner_id')
       .eq('user_id', currentUserId)
       .single()
   );
 
   if (currentProfileError || !currentProfile) {
     return { error: 'Unable to retrieve your profile.' };
+  }
+
+  if (currentProfile.id === partnerProfile.id) {
+    return { error: 'Cannot connect with yourself.' };
+  }
+
+  if (
+    (currentProfile.partner_id && currentProfile.partner_id !== partnerProfile.id) ||
+    (partnerProfile.partner_id && partnerProfile.partner_id !== currentProfile.id)
+  ) {
+    return { error: 'User already paired' };
   }
 
   const { error: updateError } = await withRetry(() =>
@@ -91,7 +102,7 @@ export const connectByCode = async (code: string, currentUserId: string) => {
   const { data: partnerProfile, error: findError } = await withRetry(() =>
     supabase
       .from('profiles')
-      .select('id, user_id, name')
+      .select('id, user_id, name, partner_id')
       .eq('short_code', code)
       .single()
   );
@@ -103,13 +114,24 @@ export const connectByCode = async (code: string, currentUserId: string) => {
   const { data: currentProfile, error: currentProfileError } = await withRetry(() =>
     supabase
       .from('profiles')
-      .select('id')
+      .select('id, partner_id')
       .eq('user_id', currentUserId)
       .single()
   );
 
   if (currentProfileError || !currentProfile) {
     return { error: 'Unable to retrieve your profile.' };
+  }
+
+  if (currentProfile.id === partnerProfile.id) {
+    return { error: 'Cannot connect with yourself.' };
+  }
+
+  if (
+    (currentProfile.partner_id && currentProfile.partner_id !== partnerProfile.id) ||
+    (partnerProfile.partner_id && partnerProfile.partner_id !== currentProfile.id)
+  ) {
+    return { error: 'User already paired' };
   }
 
   const { error: updateError } = await withRetry(() =>


### PR DESCRIPTION
## Summary
- prevent self and double partner pairing by checking existing partner_id values
- add integration tests for self-pairing and double-pairing scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689108bddf4c8331a42ed883f6b29d1f