### PR TITLE
Reuse push subscriptions and enforce uniqueness

### DIFF
--- a/supabase/migrations/20250801020000-add-unique-push-subscriptions.sql
+++ b/supabase/migrations/20250801020000-add-unique-push-subscriptions.sql
@@ -1,0 +1,8 @@
+-- Ensure one push subscription per device
+DO $$
+BEGIN
+  ALTER TABLE public.push_subscriptions
+  ADD CONSTRAINT push_subscriptions_user_id_endpoint_key UNIQUE (user_id, endpoint);
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;


### PR DESCRIPTION
## Summary
- upsert push subscriptions to reuse existing records
- clean up stale push subscriptions on logout or failure
- add unique constraint to push subscriptions table

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689108b92f1c8331b25f6db827fc8d07