### PR TITLE
Ensure partner linking rolls back on failure

### DIFF
--- a/src/services/auth.test.ts
+++ b/src/services/auth.test.ts
@@ -1,6 +1,11 @@
+import { vi } from 'vitest';
+
+vi.mock('@/lib/retry', () => ({
+  withRetry: (fn: any) => fn(),
+}));
+
 import { signIn, connectPartner } from './auth';
 import { supabase } from '@/integrations/supabase/client';
-import { vi } from 'vitest';
 
 test('signIn calls supabase auth method', async () => {
   await signIn('test@example.com', 'password');
@@ -16,6 +21,9 @@ describe('partner connections', () => {
     const qb: any = supabase.from('profiles');
     qb.single.mockReset();
     qb.update.mockReset();
+    qb.eq.mockReset();
+    qb.update.mockReturnThis();
+    qb.eq.mockReturnThis();
   });
 
   test('prevents self pairing', async () => {
@@ -67,5 +75,32 @@ describe('partner connections', () => {
     const result = await connectPartner('partner@example.com', 'user1');
     expect(result).toEqual({ error: 'User already paired' });
     expect(qb.update).not.toHaveBeenCalled();
+  });
+
+  test('rolls back when partner update fails', async () => {
+    const qb: any = supabase.from('profiles');
+    qb.single
+      .mockResolvedValueOnce({
+        data: { id: 2, user_id: 'user2', name: 'User2', partner_id: null },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { id: 1, partner_id: null },
+        error: null,
+      });
+
+    qb.eq
+      .mockImplementationOnce(() => qb)
+      .mockImplementationOnce(() => qb)
+      .mockResolvedValueOnce({ error: null })
+      .mockResolvedValueOnce({ error: 'db error' })
+      .mockResolvedValueOnce({ error: null });
+
+    const result = await connectPartner('partner@example.com', 'user1');
+
+    expect(result).toEqual({ error: 'Unable to connect with partner. Please try again.' });
+    expect(qb.update).toHaveBeenNthCalledWith(1, { partner_id: 2 });
+    expect(qb.update).toHaveBeenNthCalledWith(2, { partner_id: 1 });
+    expect(qb.update).toHaveBeenNthCalledWith(3, { partner_id: null });
   });
 });

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -92,6 +92,12 @@ export const connectPartner = async (
   );
 
   if (partnerUpdateError) {
+    await withRetry(() =>
+      supabase
+        .from('profiles')
+        .update({ partner_id: null })
+        .eq('user_id', currentUserId)
+    );
     return { error: 'Unable to connect with partner. Please try again.' };
   }
 
@@ -153,6 +159,12 @@ export const connectByCode = async (code: string, currentUserId: string) => {
   );
 
   if (partnerUpdateError) {
+    await withRetry(() =>
+      supabase
+        .from('profiles')
+        .update({ partner_id: null })
+        .eq('user_id', currentUserId)
+    );
     return { error: 'Unable to connect with partner. Please try again.' };
   }
 


### PR DESCRIPTION
## Summary
- rollback partner links if the second profile update fails
- mock retry helper in tests and verify rollback behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68911319c490833194ee55af401e0ab7