### PR TITLE
refactor: use centralized logger in pages

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,42 @@
+const isProd = import.meta.env.PROD;
+
+type LogArgs = unknown[];
+
+const sanitize = (arg: unknown): unknown => {
+  if (typeof arg === 'string') {
+    // basic email pattern replacement
+    return arg.replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, '[redacted-email]');
+  }
+  return arg;
+};
+
+const sendToRemote = (level: 'info' | 'error', args: LogArgs) => {
+  try {
+    fetch('/api/logs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ level, args: args.map((a) => sanitize(a)) }),
+    });
+  } catch {
+    // ignore logging errors in production
+  }
+};
+
+const logger = {
+  info: (...args: LogArgs) => {
+    if (!isProd) {
+      console.log(...args.map((a) => sanitize(a)));
+    } else {
+      sendToRemote('info', args);
+    }
+  },
+  error: (...args: LogArgs) => {
+    if (!isProd) {
+      console.error(...args.map((a) => sanitize(a)));
+    } else {
+      sendToRemote('error', args);
+    }
+  },
+};
+
+export default logger;

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,13 +1,14 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
 import { View, Text, TouchableOpacity, StyleSheet, Linking } from "react-native";
+import logger from '@/lib/logger';
 
 const NotFound = () => {
   const location = useLocation();
 
   useEffect(() => {
-    console.error(
-      "404 Error: User attempted to access non-existent route:",
+    logger.error(
+      '404 Error: User attempted to access non-existent route:',
       location.pathname
     );
   }, [location.pathname]);

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -31,8 +31,6 @@ const Contact: React.FC = () => {
       const stored = JSON.parse(localStorage.getItem('contactRequests') || '[]');
       stored.push(request);
       localStorage.setItem('contactRequests', JSON.stringify(stored));
-    } else {
-      console.log('Submitting contact request', request);
     }
     toast({ description: 'Request submitted' });
     setMessage('');

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -9,6 +9,7 @@ import { Heart, Bell, Settings, Shield, Calendar, MessageCircle, LogOut, User } 
 import { useAuth } from '@/contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from '@/i18n';
+import logger from '@/lib/logger';
 
 const Dashboard = () => {
   const { user, logout } = useAuth();
@@ -16,7 +17,7 @@ const Dashboard = () => {
   const { t } = useTranslation();
   
   const handleEmojiSend = (emoji: string, category: string) => {
-    console.log(`Sending ${emoji} from ${category} category`);
+    logger.info(`Sending ${emoji} from ${category} category`);
     // Here you would implement the actual sending logic
   };
   

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/components/ui/accordion';
 import { PulseButton } from '@/components/ui/pulse-button';
 import { Textarea } from '@/components/ui/textarea';
+import logger from '@/lib/logger';
 
 interface FAQItem {
   question: string;
@@ -25,7 +26,7 @@ const FAQ: React.FC = () => {
         const data = await res.json();
         setItems(data);
       } catch (err) {
-        console.error('Failed to load FAQ', err);
+        logger.error('Failed to load FAQ', err);
       }
     };
     loadFAQ();

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { PulseButton } from '@/components/ui/pulse-button';
+import logger from '@/lib/logger';
 
 interface Pulse {
   id: string;
@@ -43,7 +44,7 @@ const History: React.FC = () => {
       if (!error && data) {
         setPulses(data as Pulse[]);
       } else {
-        console.error('Error fetching pulses:', error);
+        logger.error('Error fetching pulses:', error);
       }
       setLoading(false);
     };

--- a/src/pages/messages.tsx
+++ b/src/pages/messages.tsx
@@ -4,12 +4,13 @@ import { EmojiPicker } from '@/components/communication/emoji-picker';
 import { PulseButton } from '@/components/ui/pulse-button';
 import { ArrowLeft } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
+import logger from '@/lib/logger';
 
 const Messages: React.FC = () => {
   const navigate = useNavigate();
 
   const handleEmojiSend = (emoji: string, category: string) => {
-    console.log('Sending emoji:', emoji, 'from category:', category);
+    logger.info('Sending emoji:', emoji, 'from category:', category);
     // This would integrate with the MessageCenter to send emojis
   };
 

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -38,6 +38,7 @@ import {
 import { useAuth } from '@/contexts/AuthContext';
 import { Link, useNavigate } from 'react-router-dom';
 import { cn } from '@/lib/utils';
+import logger from '@/lib/logger';
 import { supabase } from '@/integrations/supabase/client';
 import type { Tables, TablesUpdate } from '@/integrations/supabase/types';
 
@@ -126,7 +127,7 @@ const Settings: React.FC = () => {
         .single();
 
       if (error) {
-        console.error('Error loading settings:', error);
+        logger.error('Error loading settings:', error);
         return;
       }
 
@@ -172,7 +173,7 @@ const Settings: React.FC = () => {
     );
 
     if (error || scheduleError) {
-      console.error('Error saving settings:', error || scheduleError);
+      logger.error('Error saving settings:', error || scheduleError);
       toast({ description: 'Failed to save settings' });
     } else {
       toast({ description: 'Settings saved' });
@@ -193,7 +194,7 @@ const Settings: React.FC = () => {
       setSettings({ ...settings, avatar: data.publicUrl });
       toast({ title: 'Avatar updated' });
     } catch (error) {
-      console.error('Error uploading avatar:', error);
+      logger.error('Error uploading avatar:', error);
       toast({
         title: 'Upload failed',
         description: 'Could not upload avatar.',
@@ -337,7 +338,7 @@ const Settings: React.FC = () => {
         description: 'Your data has been downloaded.',
       });
     } catch (error) {
-      console.error('Error exporting data:', error);
+      logger.error('Error exporting data:', error);
       toast({
         title: 'Export failed',
         description: 'Could not export your data.',
@@ -375,7 +376,7 @@ const Settings: React.FC = () => {
       await navigator.credentials.get({ publicKey: authOptions });
       return true;
     } catch (error) {
-      console.error('Biometric registration failed', error);
+      logger.error('Biometric registration failed', error);
       return false;
     }
   };


### PR DESCRIPTION
## Summary
- add centralized logger utility
- replace console usage in pages with shared logger and remove sensitive logging

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type @typescript-eslint/no-explicit-any)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891238f713c8331a445f5f60a0fb360