### PR TITLE
feat: centralize config management

### DIFF
--- a/src/components/ui/error-boundary.tsx
+++ b/src/components/ui/error-boundary.tsx
@@ -2,6 +2,7 @@ import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { PulseButton } from '@/components/ui/pulse-button';
 import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { NODE_ENV } from '@/config';
 
 interface Props {
   children: ReactNode;
@@ -41,7 +42,7 @@ class ErrorBoundary extends Component<Props, State> {
                 We're sorry, but something unexpected happened. Don't worry, your connection with your partner is safe.
               </p>
               
-              {process.env.NODE_ENV === 'development' && this.state.error && (
+              {NODE_ENV === 'development' && this.state.error && (
                 <div className="p-3 bg-muted rounded-lg">
                   <p className="text-sm font-mono text-destructive">
                     {this.state.error.message}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('production'),
+  EXPO_PUBLIC_SUPABASE_URL: z.string().url(),
+  EXPO_PUBLIC_SUPABASE_KEY: z.string().min(1),
+  EXPO_PUBLIC_VAPID_PUBLIC_KEY: z.string().min(1),
+});
+
+const env = envSchema.parse(process.env);
+
+export const {
+  NODE_ENV,
+  EXPO_PUBLIC_SUPABASE_URL,
+  EXPO_PUBLIC_SUPABASE_KEY,
+  EXPO_PUBLIC_VAPID_PUBLIC_KEY,
+} = env;
+
+export type Env = z.infer<typeof envSchema>;

--- a/src/hooks/use-push-notifications.ts
+++ b/src/hooks/use-push-notifications.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import * as Notifications from 'expo-notifications';
+import { EXPO_PUBLIC_VAPID_PUBLIC_KEY } from '@/config';
 
 function urlBase64ToUint8Array(base64String: string): Uint8Array {
   const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
@@ -54,14 +55,13 @@ export function usePushNotifications() {
 
           let subscription = await registration.pushManager.getSubscription();
           if (!subscription) {
-            const publicKey = process.env.EXPO_PUBLIC_VAPID_PUBLIC_KEY;
-            if (!publicKey) {
+            if (!EXPO_PUBLIC_VAPID_PUBLIC_KEY) {
               console.warn('VAPID public key is not set');
               return;
             }
             subscription = await registration.pushManager.subscribe({
               userVisibleOnly: true,
-              applicationServerKey: urlBase64ToUint8Array(publicKey),
+              applicationServerKey: urlBase64ToUint8Array(EXPO_PUBLIC_VAPID_PUBLIC_KEY),
             });
           }
 

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -3,18 +3,23 @@ import 'react-native-url-polyfill/auto';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
-
-const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL || '';
-const SUPABASE_KEY = process.env.EXPO_PUBLIC_SUPABASE_KEY || '';
+import {
+  EXPO_PUBLIC_SUPABASE_URL,
+  EXPO_PUBLIC_SUPABASE_KEY,
+} from '@/config';
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";
 
-export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_KEY, {
-  auth: {
-    storage: AsyncStorage,
-    persistSession: true,
-    autoRefreshToken: true,
-    detectSessionInUrl: false,
+export const supabase = createClient<Database>(
+  EXPO_PUBLIC_SUPABASE_URL,
+  EXPO_PUBLIC_SUPABASE_KEY,
+  {
+    auth: {
+      storage: AsyncStorage,
+      persistSession: true,
+      autoRefreshToken: true,
+      detectSessionInUrl: false,
+    },
   },
-});
+);

--- a/supabase/functions/auto-delete-messages/index.ts
+++ b/supabase/functions/auto-delete-messages/index.ts
@@ -1,20 +1,29 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
+const CRON_AUTH_TOKEN = Deno.env.get("CRON_AUTH_TOKEN");
+if (!CRON_AUTH_TOKEN) {
+  throw new Error("Missing CRON_AUTH_TOKEN environment variable");
+}
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL");
+if (!SUPABASE_URL) {
+  throw new Error("Missing SUPABASE_URL environment variable");
+}
+const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+if (!SUPABASE_SERVICE_ROLE_KEY) {
+  throw new Error("Missing SUPABASE_SERVICE_ROLE_KEY environment variable");
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
 serve(async (req) => {
-  const token = Deno.env.get("CRON_AUTH_TOKEN");
   const authHeader = req.headers.get("authorization");
-  if (!token || authHeader !== `Bearer ${token}`) {
+  if (authHeader !== `Bearer ${CRON_AUTH_TOKEN}`) {
     return new Response(JSON.stringify({ error: "Unauthorized" }), {
       status: 401,
       headers: { "Content-Type": "application/json" },
     });
   }
-
-  const supabase = createClient(
-    Deno.env.get("SUPABASE_URL")!,
-    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
-  );
 
   const cutoff = new Date();
   cutoff.setDate(cutoff.getDate() - 30);


### PR DESCRIPTION
## Summary
- add zod-based config module for environment variables
- consume centralized config in app code
- validate required env vars in serverless functions

## Testing
- `NODE_ENV=test EXPO_PUBLIC_SUPABASE_URL='https://example.com' EXPO_PUBLIC_SUPABASE_KEY='key' EXPO_PUBLIC_VAPID_PUBLIC_KEY='key' npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891239682dc8331b90c551715ee6f0f