### PR TITLE
feat: add wearable energy cycle integration

### DIFF
--- a/src/integrations/wearable/index.ts
+++ b/src/integrations/wearable/index.ts
@@ -1,0 +1,40 @@
+export interface EnergyCycleMetrics {
+  /**
+   * Current phase of the user's energy cycle as reported by the wearable.
+   * e.g. "peak", "low", "recovery".
+   */
+  phase: string;
+}
+
+interface WearableAPI {
+  requestPermission?: () => Promise<'granted' | 'denied'>;
+  getEnergyCycle?: () => Promise<EnergyCycleMetrics>;
+}
+
+/**
+ * Attempt to fetch energy cycle metrics from a connected wearable device.
+ *
+ * Returns `null` when the wearable API isn't available or the user hasn't
+ * granted the necessary permissions.
+ */
+export async function fetchEnergyCycleMetrics(): Promise<EnergyCycleMetrics | null> {
+  const nav = navigator as Navigator & { wearable?: WearableAPI };
+  const wearable: WearableAPI | undefined = nav.wearable;
+
+  if (!wearable?.requestPermission || !wearable?.getEnergyCycle) {
+    return null;
+  }
+
+  try {
+    const permission = await wearable.requestPermission();
+    if (permission !== 'granted') {
+      return null;
+    }
+
+    const metrics = await wearable.getEnergyCycle();
+    return metrics ?? null;
+  } catch (error) {
+    console.error('Failed to fetch energy cycle metrics', error);
+    return null;
+  }
+}

--- a/src/pages/insights.tsx
+++ b/src/pages/insights.tsx
@@ -6,6 +6,7 @@ import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts';
 import { Sparkles, BarChart3, ArrowLeft } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
+import { fetchEnergyCycleMetrics } from '@/integrations/wearable';
 import { useNavigate } from 'react-router-dom';
 import { cn } from '@/lib/utils';
 
@@ -45,19 +46,27 @@ const Insights: React.FC = () => {
 
       setChartData(dayLabels.map((d, i) => ({ day: d, pulses: dayCounts[i] })));
 
+      const suggestionList: string[] = [];
       if (pulses.length > 0) {
         const topDayIndex = dayCounts.indexOf(Math.max(...dayCounts));
         const topHourIndex = hourCounts.indexOf(Math.max(...hourCounts));
         const hourDate = new Date();
         hourDate.setHours(topHourIndex, 0, 0, 0);
         const formattedHour = hourDate.toLocaleTimeString([], { hour: 'numeric' });
-        setSuggestions([
+        suggestionList.push(
           `Most pulses land on ${fullDayLabels[topDayIndex]}s`,
           `Peak hour is around ${formattedHour}`
-        ]);
+        );
       } else {
-        setSuggestions(['No pulse history yet. Send some pulses to see insights!']);
+        suggestionList.push('No pulse history yet. Send some pulses to see insights!');
       }
+
+      const energyCycle = await fetchEnergyCycleMetrics();
+      if (energyCycle?.phase) {
+        suggestionList.push(`Current energy cycle: ${energyCycle.phase}`);
+      }
+
+      setSuggestions(suggestionList);
     };
 
     fetchHistory();


### PR DESCRIPTION
## Summary
- add wearable integration module for energy cycle metrics
- include energy cycle data in insights suggestions when available

## Testing
- `npm run lint` (fails: Unexpected any in existing test files)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891293332348331aa45698f1e1904f2