### PR TITLE
feat: add age verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 **URL**: https://lovable.dev/projects/87a2c8c0-a491-491c-867d-7c092b5d4541
 
+## Age Policy
+
+Pulse is intended for users who meet minimum digital consent ages. You must be
+at least **13 years old** to create an account, or **16 years old** if you are
+located in a European Union member state. Your birthdate is requested during
+registration and sign‑up is blocked for underage users.
+
 ## How can I edit this code?
 
 There are several ways of editing your application.

--- a/app.json
+++ b/app.json
@@ -4,7 +4,8 @@
     "slug": "pulse",
     "version": "1.0.0",
     "orientation": "portrait",
-    "platforms": ["ios", "android"]
+    "platforms": ["ios", "android"],
+    "description": "Pulse helps couples stay connected. Users must be 13+ (16+ in EU)."
   }
 }
 

--- a/src/components/auth/auth-card.tsx
+++ b/src/components/auth/auth-card.tsx
@@ -10,20 +10,40 @@ import { useNavigate } from 'react-router-dom';
 import { useToast } from '@/hooks/use-toast';
 import { supabase } from '@/integrations/supabase/client';
 
+const EU_COUNTRIES = [
+  'AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR', 'HU',
+  'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL', 'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE'
+];
+
+const getAgeLimit = (code: string) => (EU_COUNTRIES.includes(code) ? 16 : 13);
+
+const calculateAge = (birthdate: string) => {
+  const today = new Date();
+  const birth = new Date(birthdate);
+  let age = today.getFullYear() - birth.getFullYear();
+  const m = today.getMonth() - birth.getMonth();
+  if (m < 0 || (m === 0 && today.getDate() < birth.getDate())) {
+    age--;
+  }
+  return age;
+};
+
 interface AuthCardProps {
   mode: 'login' | 'register' | 'connect';
   onModeChange: (mode: 'login' | 'register' | 'connect') => void;
   className?: string;
+  country: string;
 }
 
-export const AuthCard: React.FC<AuthCardProps> = ({ mode, onModeChange, className }) => {
+export const AuthCard: React.FC<AuthCardProps> = ({ mode, onModeChange, className, country }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [formData, setFormData] = useState({
     name: '',
     email: '',
     password: '',
     confirmPassword: '',
-    partnerEmail: ''
+    partnerEmail: '',
+    birthdate: ''
   });
   
   const { signIn, signUp, connectPartner, user } = useAuth();
@@ -72,7 +92,17 @@ export const AuthCard: React.FC<AuthCardProps> = ({ mode, onModeChange, classNam
             alert('Passwords do not match');
             return;
           }
-          success = await signUp(formData.name, formData.email, formData.password);
+          const age = calculateAge(formData.birthdate);
+          const ageLimit = getAgeLimit(country);
+          if (age < ageLimit) {
+            toast({
+              title: 'Underage',
+              description: `You must be at least ${ageLimit} years old to use Pulse.`,
+              variant: 'destructive',
+            });
+            return;
+          }
+          success = await signUp(formData.name, formData.email, formData.password, formData.birthdate);
           break;
         case 'connect':
           success = await connectPartner(formData.partnerEmail);
@@ -180,12 +210,22 @@ export const AuthCard: React.FC<AuthCardProps> = ({ mode, onModeChange, classNam
               </div>
               <div className="space-y-2">
                 <Label htmlFor="confirmPassword">Confirm Password</Label>
-                <Input 
-                  id="confirmPassword" 
-                  type="password" 
+                <Input
+                  id="confirmPassword"
+                  type="password"
                   placeholder="••••••••"
                   value={formData.confirmPassword}
                   onChange={(e) => handleInputChange('confirmPassword', e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="birthdate">Birthdate</Label>
+                <Input
+                  id="birthdate"
+                  type="date"
+                  value={formData.birthdate}
+                  onChange={(e) => handleInputChange('birthdate', e.target.value)}
                   required
                 />
               </div>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -19,7 +19,7 @@ interface AuthContextType {
   user: User | null;
   isLoading: boolean;
   signIn: (email: string, password: string) => Promise<boolean>;
-  signUp: (name: string, email: string, password: string) => Promise<boolean>;
+  signUp: (name: string, email: string, password: string, birthdate?: string) => Promise<boolean>;
   connectPartner: (partnerEmail: string) => Promise<boolean>;
   connectByCode: (code: string) => Promise<boolean>;
   logout: () => void;
@@ -128,10 +128,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   };
 
-  const signUp = async (name: string, email: string, password: string): Promise<boolean> => {
+  const signUp = async (name: string, email: string, password: string, birthdate?: string): Promise<boolean> => {
     setIsLoading(true);
     try {
-      const { error } = await authService.signUp(name, email, password);
+      const { error } = await authService.signUp(name, email, password, birthdate);
       if (error) {
         toast({
           title: 'Registration failed',

--- a/src/pages/auth.tsx
+++ b/src/pages/auth.tsx
@@ -8,6 +8,7 @@ const Auth = () => {
   const [searchParams] = useSearchParams();
   const initialMode = (searchParams.get('mode') as 'login' | 'register' | 'connect') || 'login';
   const [authMode, setAuthMode] = useState<'login' | 'register' | 'connect'>(initialMode);
+  const [country, setCountry] = useState<string>('US');
 
   useEffect(() => {
     const mode = searchParams.get('mode') as 'login' | 'register' | 'connect' | null;
@@ -15,6 +16,26 @@ const Auth = () => {
       setAuthMode(mode);
     }
   }, [searchParams]);
+
+  useEffect(() => {
+    const locale = navigator.language;
+    const match = locale.match(/-([A-Z]{2})$/);
+    if (match) {
+      setCountry(match[1]);
+      return;
+    }
+
+    fetch('https://ipapi.co/json/')
+      .then((res) => res.json())
+      .then((data) => {
+        if (data?.country_code) {
+          setCountry(data.country_code);
+        }
+      })
+      .catch(() => {
+        // Ignore errors and keep default country
+      });
+  }, []);
 
   return (
     <div className="min-h-screen bg-gradient-soft">
@@ -47,9 +68,10 @@ const Auth = () => {
 
           {/* Auth Card */}
           <div className="flex justify-center">
-            <AuthCard 
-              mode={authMode} 
+            <AuthCard
+              mode={authMode}
               onModeChange={setAuthMode}
+              country={country}
               className="animate-scale-in"
             />
           </div>

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -5,7 +5,7 @@ export const signIn = (email: string, password: string) => {
   return withRetry(() => supabase.auth.signInWithPassword({ email, password }));
 };
 
-export const signUp = (name: string, email: string, password: string) => {
+export const signUp = (name: string, email: string, password: string, birthdate?: string) => {
   const redirectUrl = `${window.location.origin}/`;
   return withRetry(() =>
     supabase.auth.signUp({
@@ -13,7 +13,7 @@ export const signUp = (name: string, email: string, password: string) => {
       password,
       options: {
         emailRedirectTo: redirectUrl,
-        data: { name }
+        data: { name, birthdate }
       }
     })
   );


### PR DESCRIPTION
## Summary
- detect user country on auth page and pass to registration
- request birthdate and enforce regional age limits during sign-up
- document age policy and update store metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68912930780c8331823656c93445c4a9