### PR TITLE
feat: add language-aware input limits

### DIFF
--- a/docs/translation-glossary.md
+++ b/docs/translation-glossary.md
@@ -25,3 +25,16 @@ Avoid explicit terms. Use the suggested neutral alternatives instead.
 | sexe | sexualité |
 | rapports | relations intimes |
 
+## Character Limits
+
+Default input elements are constrained to preserve layout across languages.
+
+| Field | English | French |
+| --- | --- | --- |
+| Default Input | 100 | 80 |
+| Default Textarea | 500 | 400 |
+| Name | 50 | 40 |
+| Bio | 160 | 120 |
+| Email | 254 | 254 |
+| Message | 500 | 400 |
+

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,9 +1,21 @@
 import * as React from "react"
 
+import { useTranslation } from "@/i18n"
 import { cn } from "@/lib/utils"
 
-const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-  ({ className, type, ...props }, ref) => {
+type InputProps = React.ComponentProps<"input"> & {
+  maxLength?: number
+}
+
+const defaultMaxLength = {
+  en: 100,
+  fr: 80,
+} as const
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, maxLength, ...props }, ref) => {
+    const { lang } = useTranslation()
+    const computedMax = maxLength ?? defaultMaxLength[lang]
     return (
       <input
         type={type}
@@ -13,6 +25,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
         )}
         ref={ref}
         {...props}
+        {...(type !== "file" ? { maxLength: computedMax } : {})}
       />
     )
   }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,12 +1,22 @@
 import * as React from "react"
 
+import { useTranslation } from "@/i18n"
 import { cn } from "@/lib/utils"
 
 export type TextareaProps =
-  React.TextareaHTMLAttributes<HTMLTextAreaElement>
+  React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+    maxLength?: number
+  }
+
+const defaultMaxLength = {
+  en: 500,
+  fr: 400,
+} as const
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ className, ...props }, ref) => {
+  ({ className, maxLength, ...props }, ref) => {
+    const { lang } = useTranslation()
+    const computedMax = maxLength ?? defaultMaxLength[lang]
     return (
       <textarea
         className={cn(
@@ -14,6 +24,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
           className
         )}
         ref={ref}
+        maxLength={computedMax}
         {...props}
       />
     )

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -6,6 +6,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { PulseButton } from '@/components/ui/pulse-button';
 import { useToast } from '@/hooks/use-toast';
 import { useAuth } from '@/contexts/AuthContext';
+import { useTranslation } from '@/i18n';
 
 const Contact: React.FC = () => {
   const { user } = useAuth();
@@ -13,6 +14,7 @@ const Contact: React.FC = () => {
   const [isOnline, setIsOnline] = useState<boolean>(navigator.onLine);
   const [email, setEmail] = useState<string>(user?.email || '');
   const [message, setMessage] = useState<string>('');
+  const { lang } = useTranslation();
 
   useEffect(() => {
     const updateStatus = () => setIsOnline(navigator.onLine);
@@ -57,6 +59,7 @@ const Contact: React.FC = () => {
                   type="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
+                  maxLength={254}
                 />
               </div>
               <div className="space-y-2">
@@ -65,6 +68,7 @@ const Contact: React.FC = () => {
                   id="message"
                   value={message}
                   onChange={(e) => setMessage(e.target.value)}
+                  maxLength={lang === 'fr' ? 400 : 500}
                 />
               </div>
               <PulseButton type="submit">Submit</PulseButton>

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -8,6 +8,7 @@ import {
 import { PulseButton } from '@/components/ui/pulse-button';
 import { Textarea } from '@/components/ui/textarea';
 import logger from '@/lib/logger';
+import { useTranslation } from '@/i18n';
 
 interface FAQItem {
   question: string;
@@ -18,6 +19,7 @@ const FAQ: React.FC = () => {
   const [items, setItems] = useState<FAQItem[]>([]);
   const [showOfflineForm, setShowOfflineForm] = useState(false);
   const [message, setMessage] = useState('');
+  const { lang } = useTranslation();
 
   useEffect(() => {
     const loadFAQ = async () => {
@@ -67,6 +69,7 @@ const FAQ: React.FC = () => {
             value={message}
             onChange={(e) => setMessage(e.target.value)}
             placeholder="Your message"
+            maxLength={lang === 'fr' ? 400 : 500}
           />
           <PulseButton type="submit">Save Message</PulseButton>
         </form>

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -479,7 +479,7 @@ const Settings: React.FC = () => {
                       </AvatarFallback>
                     </Avatar>
                     <div>
-                      <input
+                      <Input
                         ref={fileInputRef}
                         type="file"
                         accept="image/*"
@@ -504,6 +504,7 @@ const Settings: React.FC = () => {
                         id="name"
                         value={settings.name}
                         onChange={(e) => setSettings({ ...settings, name: e.target.value })}
+                        maxLength={lang === 'fr' ? 40 : 50}
                       />
                     </div>
                     <div className="space-y-2">
@@ -513,6 +514,7 @@ const Settings: React.FC = () => {
                         type="email"
                         value={settings.email}
                         onChange={(e) => setSettings({ ...settings, email: e.target.value })}
+                        maxLength={254}
                       />
                     </div>
                   </div>
@@ -524,6 +526,7 @@ const Settings: React.FC = () => {
                       value={settings.bio}
                       onChange={(e) => setSettings({ ...settings, bio: e.target.value })}
                       placeholder="Tell your partner something sweet..."
+                      maxLength={lang === 'fr' ? 120 : 160}
                     />
                   </div>
 


### PR DESCRIPTION
## Summary
- default `Input` and `Textarea` max lengths by current language
- enforce field limits across pages
- document expected character lengths

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6891292e6dac8331a7654a425ea2c9dc