### PR TITLE
feat: add professional resources link

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -42,6 +42,7 @@ const translations = {
     statusBusyDescription: 'Catch you later',
     statusNotAvailableLabel: 'Not Available',
     statusNotAvailableDescription: 'Need a moment',
+    proResources: 'Certified sexologists',
   },
   fr: {
     addFirstAvailability: 'Ajoutez votre première disponibilité',
@@ -84,6 +85,7 @@ const translations = {
     statusBusyDescription: 'À plus tard',
     statusNotAvailableLabel: 'Indisponible',
     statusNotAvailableDescription: "Besoin d'un moment",
+    proResources: 'Sexologues certifiés',
   },
 } as const;
 

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -8,6 +8,7 @@ import {
 import { PulseButton } from '@/components/ui/pulse-button';
 import { Textarea } from '@/components/ui/textarea';
 import logger from '@/lib/logger';
+import { useTranslation } from '@/i18n';
 
 interface FAQItem {
   question: string;
@@ -18,6 +19,7 @@ const FAQ: React.FC = () => {
   const [items, setItems] = useState<FAQItem[]>([]);
   const [showOfflineForm, setShowOfflineForm] = useState(false);
   const [message, setMessage] = useState('');
+  const { t } = useTranslation();
 
   useEffect(() => {
     const loadFAQ = async () => {
@@ -61,6 +63,16 @@ const FAQ: React.FC = () => {
           </AccordionItem>
         ))}
       </Accordion>
+      <div className="mb-8">
+        <a
+          href="https://www.aasect.org/referral-directory"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary underline"
+        >
+          {t('proResources')}
+        </a>
+      </div>
       {showOfflineForm ? (
         <form onSubmit={handleOfflineSubmit} className="space-y-4">
           <Textarea

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -854,6 +854,15 @@ const Settings: React.FC = () => {
                     <PulseButton asChild variant="ghost" size="sm">
                       <Link to="/contact">Contact Support</Link>
                     </PulseButton>
+                    <PulseButton asChild variant="ghost" size="sm">
+                      <a
+                        href="https://www.aasect.org/referral-directory"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {t('proResources')}
+                      </a>
+                    </PulseButton>
                   </div>
                 </div>
               )}


### PR DESCRIPTION
## Summary
- add `proResources` translation for certified sexologists
- link to certified sexologists from FAQ page
- surface professional resources link in settings help section

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in test files)*

------
https://chatgpt.com/codex/tasks/task_e_6891292cfc948331b124d50dd51db960