### PR TITLE
feat: localize help links

### DIFF
--- a/src/components/auth/auth-card.tsx
+++ b/src/components/auth/auth-card.tsx
@@ -9,6 +9,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { useToast } from '@/hooks/use-toast';
 import { supabase } from '@/integrations/supabase/client';
+import { useTranslation } from '@/i18n';
 
 interface AuthCardProps {
   mode: 'login' | 'register' | 'connect';
@@ -29,6 +30,7 @@ export const AuthCard: React.FC<AuthCardProps> = ({ mode, onModeChange, classNam
   const { signIn, signUp, connectPartner, user } = useAuth();
   const navigate = useNavigate();
   const { toast } = useToast();
+  const { t } = useTranslation();
   
   const handleInputChange = (field: string, value: string) => {
     setFormData(prev => ({ ...prev, [field]: value }));
@@ -267,9 +269,9 @@ export const AuthCard: React.FC<AuthCardProps> = ({ mode, onModeChange, classNam
           button: 'Connect',
           footer: (
             <p className="text-sm text-muted-foreground text-center">
-              Need help?{' '}
+              {t('needHelp')}{' '}
               <button className="text-primary hover:underline font-medium">
-                Contact support
+                {t('contactSupport')}
               </button>
             </p>
           )

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -42,6 +42,9 @@ const translations = {
     statusBusyDescription: 'Catch you later',
     statusNotAvailableLabel: 'Not Available',
     statusNotAvailableDescription: 'Need a moment',
+    needHelp: 'Need help?',
+    helpCenter: 'Help Center',
+    contactSupport: 'Contact support',
   },
   fr: {
     addFirstAvailability: 'Ajoutez votre première disponibilité',
@@ -84,6 +87,9 @@ const translations = {
     statusBusyDescription: 'À plus tard',
     statusNotAvailableLabel: 'Indisponible',
     statusNotAvailableDescription: "Besoin d'un moment",
+    needHelp: 'Besoin d’aide ?',
+    helpCenter: 'FAQ',
+    contactSupport: 'Contacter le support',
   },
 } as const;
 

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -407,7 +407,7 @@ const Settings: React.FC = () => {
     { id: 'notifications', name: 'Notifications', icon: Bell },
     { id: 'privacy', name: 'Privacy', icon: Shield },
     { id: 'general', name: 'General', icon: SettingsIcon },
-    { id: 'help', name: 'Help Center', icon: HelpCircle },
+    { id: 'help', name: t('helpCenter'), icon: HelpCircle },
   ] as const;
 
   return (
@@ -817,10 +817,10 @@ const Settings: React.FC = () => {
 
                     <div className="space-y-3">
                       <h3 className="font-medium">Support</h3>
-                      <p className="text-sm text-muted-foreground">Need help with Pulse?</p>
+                      <p className="text-sm text-muted-foreground">{t('needHelp')}</p>
                       <PulseButton onClick={() => navigate('/faq')}>
                         <LifeBuoy className="w-4 h-4 mr-2" />
-                        Help Center
+                        {t('helpCenter')}
                       </PulseButton>
                     </div>
 
@@ -849,10 +849,10 @@ const Settings: React.FC = () => {
                   </p>
                   <div className="flex flex-col sm:flex-row gap-2">
                     <PulseButton asChild variant="ghost" size="sm">
-                      <Link to="/faq">FAQ</Link>
+                      <Link to="/faq">{t('helpCenter')}</Link>
                     </PulseButton>
                     <PulseButton asChild variant="ghost" size="sm">
-                      <Link to="/contact">Contact Support</Link>
+                      <Link to="/contact">{t('contactSupport')}</Link>
                     </PulseButton>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- add i18n keys for needHelp, helpCenter, and contactSupport
- localize help links in Settings and Auth card

## Testing
- `npm test`
- `node -e "const fs=require('fs');const data=fs.readFileSync('./src/i18n.ts','utf8');const en=data.match(/needHelp: '([^']+)'/)[1]; const fr=data.match(/fr: {[\s\S]*?needHelp: '([^']+)'/)[1]; console.log(en, '|', fr);"`


------
https://chatgpt.com/codex/tasks/task_e_68912929a1348331b17497254f3f3bb6