### PR TITLE
feat: schedule trial reminder notification

### DIFF
--- a/src/hooks/use-push-notifications.ts
+++ b/src/hooks/use-push-notifications.ts
@@ -1,6 +1,34 @@
 import { useEffect, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import * as Notifications from 'expo-notifications';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useAuth } from '@/contexts/AuthContext';
+
+const TRIAL_START_KEY = 'trialStartDate';
+const TRIAL_NOTIFICATION_ID_KEY = 'trialNotificationId';
+
+const getItem = async (key: string): Promise<string | null> => {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    return window.localStorage.getItem(key);
+  }
+  return AsyncStorage.getItem(key);
+};
+
+const setItem = async (key: string, value: string) => {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    window.localStorage.setItem(key, value);
+  } else {
+    await AsyncStorage.setItem(key, value);
+  }
+};
+
+const removeItem = async (key: string) => {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    window.localStorage.removeItem(key);
+  } else {
+    await AsyncStorage.removeItem(key);
+  }
+};
 
 function urlBase64ToUint8Array(base64String: string): Uint8Array {
   const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
@@ -16,6 +44,7 @@ function urlBase64ToUint8Array(base64String: string): Uint8Array {
 }
 
 export function usePushNotifications() {
+  const { user } = useAuth();
   const notificationListener = useRef<Notifications.Subscription>();
   const responseListener = useRef<Notifications.Subscription>();
 
@@ -154,6 +183,12 @@ export function usePushNotifications() {
     } = supabase.auth.onAuthStateChange(async event => {
       if (event === 'SIGNED_OUT') {
         await pruneSubscription();
+        const id = await getItem(TRIAL_NOTIFICATION_ID_KEY);
+        if (id) {
+          await Notifications.cancelScheduledNotificationAsync(id);
+          await removeItem(TRIAL_NOTIFICATION_ID_KEY);
+        }
+        await removeItem(TRIAL_START_KEY);
       }
     });
 
@@ -167,5 +202,35 @@ export function usePushNotifications() {
       authSubscription.unsubscribe();
     };
   }, []);
+
+  useEffect(() => {
+    const handleTrial = async () => {
+      const storedId = await getItem(TRIAL_NOTIFICATION_ID_KEY);
+      if (user && !user.isPremium) {
+        const storedStart = await getItem(TRIAL_START_KEY);
+        let startDate = storedStart ? new Date(storedStart) : null;
+        if (!startDate) {
+          startDate = new Date();
+          await setItem(TRIAL_START_KEY, startDate.toISOString());
+        }
+        if (!storedId) {
+          const triggerDate = new Date(startDate.getTime() + 5 * 24 * 60 * 60 * 1000);
+          const id = await Notifications.scheduleNotificationAsync({
+            content: { body: 'Profitez de vos Insights avancés' },
+            trigger: triggerDate,
+          });
+          await setItem(TRIAL_NOTIFICATION_ID_KEY, id);
+        }
+      } else {
+        if (storedId) {
+          await Notifications.cancelScheduledNotificationAsync(storedId);
+          await removeItem(TRIAL_NOTIFICATION_ID_KEY);
+        }
+        await removeItem(TRIAL_START_KEY);
+      }
+    };
+
+    handleTrial();
+  }, [user]);
 }
 


### PR DESCRIPTION
## Summary
- store trial start date in local storage and schedule a reminder notification 5 days later
- cancel scheduled reminder when trial ends or user signs out

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in test files)*

------
https://chatgpt.com/codex/tasks/task_e_6891292915988331b9d6aa451c9526de