### PR TITLE
Centralize environment config usage

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, RefreshCw } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { PulseButton } from '@/components/ui/pulse-button';
 import { useErrorReporter } from '@/hooks/use-error-reporter';
+import { NODE_ENV } from '@/config';
 
 interface Props {
   children: ReactNode;
@@ -46,7 +47,7 @@ class ErrorBoundaryInner extends Component<BoundaryProps, State> {
                 We're sorry, but something unexpected happened. Don't worry, your connection with your partner is safe.
               </p>
 
-              {process.env.NODE_ENV === 'development' && this.state.error && (
+              {NODE_ENV === 'development' && this.state.error && (
                 <div className="p-3 bg-muted rounded-lg">
                   <p className="text-sm font-mono text-destructive">
                     {this.state.error.message}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,11 @@
+export const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL || '';
+export const SUPABASE_KEY = process.env.EXPO_PUBLIC_SUPABASE_KEY || '';
+export const VAPID_PUBLIC_KEY = process.env.EXPO_PUBLIC_VAPID_PUBLIC_KEY || '';
+export const NODE_ENV = process.env.NODE_ENV;
+
+export const config = {
+  SUPABASE_URL,
+  SUPABASE_KEY,
+  VAPID_PUBLIC_KEY,
+  NODE_ENV,
+};

--- a/src/hooks/use-push-notifications.ts
+++ b/src/hooks/use-push-notifications.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import * as Notifications from 'expo-notifications';
+import { VAPID_PUBLIC_KEY } from '@/config';
 
 function urlBase64ToUint8Array(base64String: string): Uint8Array {
   const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
@@ -54,7 +55,7 @@ export function usePushNotifications() {
 
           let subscription = await registration.pushManager.getSubscription();
           if (!subscription) {
-            const publicKey = process.env.EXPO_PUBLIC_VAPID_PUBLIC_KEY;
+            const publicKey = VAPID_PUBLIC_KEY;
             if (!publicKey) {
               console.warn('VAPID public key is not set');
               return;

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -3,9 +3,7 @@ import 'react-native-url-polyfill/auto';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
-
-const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL || '';
-const SUPABASE_KEY = process.env.EXPO_PUBLIC_SUPABASE_KEY || '';
+import { SUPABASE_URL, SUPABASE_KEY } from '@/config';
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";


### PR DESCRIPTION
## Summary
- add central `config` module exporting environment settings
- route Supabase client and push notification hook through shared config
- use config-driven NODE_ENV in error boundary

## Testing
- `npm run lint` (fails: Unexpected any)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68912aec84ec83318ab2ace00d12929a