### PR TITLE
Add FAQ entry on handling desire disagreements

### DIFF
--- a/public/faq.json
+++ b/public/faq.json
@@ -8,5 +8,6 @@
   {"question": "Is my data secure?", "answer": "Pulse uses Supabase authentication and secure storage for your data."},
   {"question": "How do I delete my account?", "answer": "You can delete your account from the Danger Zone in Settings."},
   {"question": "What browsers are supported?", "answer": "Pulse works best on modern browsers like Chrome, Firefox, and Edge."},
-  {"question": "How do I pair with my partner?", "answer": "Use the Pair page and share the pairing code with your partner."}
+  {"question": "How do I pair with my partner?", "answer": "Use the Pair page and share the pairing code with your partner."},
+  {"question": "Comment gérer un désaccord de désir ?", "answer": "Parlez ouvertement avec votre partenaire, écoutez ses besoins et explorez des solutions ensemble. Pour en savoir plus, consultez l'article détaillé à l'adresse /articles/desaccord-de-desir."}
 ]

--- a/src/pages/articles/desaccord-de-desir.tsx
+++ b/src/pages/articles/desaccord-de-desir.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const DesaccordDeDesir = () => (
+  <div className="p-4 max-w-3xl mx-auto">
+    <h1 className="text-3xl font-serif font-bold mb-4">Comment gérer un désaccord de désir ?</h1>
+    <p>
+      Un désaccord de désir survient lorsque les partenaires n'ont pas les mêmes envies ou besoins
+      au même moment. Prendre le temps d'en parler avec respect permet de mieux comprendre les
+      attentes de chacun.
+    </p>
+    <p>
+      Exprimer clairement ses sentiments, écouter activement l'autre et chercher des compromis aide
+      à maintenir la connexion. Si nécessaire, planifiez des moments de partage et n'hésitez pas à
+      consulter un spécialiste pour un accompagnement.
+    </p>
+  </div>
+);
+
+export default DesaccordDeDesir;
+


### PR DESCRIPTION
## Summary
- add FAQ entry about managing desire disagreement and link to an article
- create `/articles/desaccord-de-desir` article page with guidance

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in tests and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6891292a2cec83318ef6cb217aaa91cc