### PR TITLE
feat: add simple messaging screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,9 +1,36 @@
-import { StyleSheet, Text, View } from 'react-native';
+import React, { useState } from 'react';
+import { StyleSheet, Text, View, TextInput, Button, FlatList } from 'react-native';
 
 export default function App() {
+  const [message, setMessage] = useState('');
+  const [messages, setMessages] = useState<string[]>([]);
+
+  const handleSend = () => {
+    const trimmed = message.trim();
+    if (!trimmed) return;
+    setMessages([...messages, trimmed]);
+    setMessage('');
+  };
+
   return (
     <View style={styles.container}>
-      <Text>Welcome to Expo</Text>
+      <Text style={styles.title}>Pulse</Text>
+      <Text style={styles.subtitle}>
+        Stay connected with your partner through shared messages
+      </Text>
+      <FlatList
+        style={styles.messages}
+        data={messages}
+        keyExtractor={(item, index) => `${item}-${index}`}
+        renderItem={({ item }) => <Text style={styles.message}>• {item}</Text>}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Type a message"
+        value={message}
+        onChangeText={setMessage}
+      />
+      <Button title="Send" onPress={handleSend} />
     </View>
   );
 }
@@ -13,6 +40,33 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 16,
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  messages: {
+    alignSelf: 'stretch',
+    marginBottom: 16,
+  },
+  message: {
+    fontSize: 16,
+    marginBottom: 4,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 4,
+    padding: 8,
+    width: '100%',
+    marginBottom: 8,
   },
 });
 


### PR DESCRIPTION
## Summary
- replace placeholder Expo welcome screen with basic messaging interface demonstrating Pulse's purpose

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6891c93557e48331acfdfdbb911aef90