### PR TITLE
test: cover signup and partner connection by code

### DIFF
--- a/src/services/auth.test.ts
+++ b/src/services/auth.test.ts
@@ -4,7 +4,7 @@ vi.mock('@/lib/retry', () => ({
   withRetry: (fn: any) => fn(),
 }));
 
-import { signIn, connectPartner } from './auth';
+import { signIn, signUp, connectPartner, connectByCode } from './auth';
 import { supabase } from '@/integrations/supabase/client';
 
 test('signIn calls supabase auth method', async () => {
@@ -12,6 +12,18 @@ test('signIn calls supabase auth method', async () => {
   expect(supabase.auth.signInWithPassword).toHaveBeenCalledWith({
     email: 'test@example.com',
     password: 'password',
+  });
+});
+
+test('signUp calls supabase auth method with profile data', async () => {
+  await signUp('Test User', 'new@example.com', 'secret', '2000-01-01');
+  expect(supabase.auth.signUp).toHaveBeenCalledWith({
+    email: 'new@example.com',
+    password: 'secret',
+    options: {
+      emailRedirectTo: `${window.location.origin}/`,
+      data: { name: 'Test User', birthdate: '2000-01-01' },
+    },
   });
 });
 
@@ -102,5 +114,74 @@ describe('partner connections', () => {
     expect(qb.update).toHaveBeenNthCalledWith(1, { partner_id: 2 });
     expect(qb.update).toHaveBeenNthCalledWith(2, { partner_id: 1 });
     expect(qb.update).toHaveBeenNthCalledWith(3, { partner_id: null });
+  });
+});
+
+describe('connect by code', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const qb: any = supabase.from('profiles');
+    qb.single.mockReset();
+    qb.update.mockReset();
+    qb.eq.mockReset();
+    qb.update.mockReturnThis();
+    qb.eq.mockReturnThis();
+  });
+
+  test('connects successfully with valid code', async () => {
+    const qb: any = supabase.from('profiles');
+    const partner = { id: 2, user_id: 'user2', name: 'User2', partner_id: null };
+    qb.single
+      .mockResolvedValueOnce({ data: partner, error: null })
+      .mockResolvedValueOnce({ data: { id: 1, partner_id: null }, error: null });
+
+    qb.eq
+      .mockImplementationOnce(() => qb)
+      .mockImplementationOnce(() => qb)
+      .mockResolvedValueOnce({ error: null })
+      .mockResolvedValueOnce({ error: null });
+
+    const result = await connectByCode('CODE123', 'user1');
+
+    expect(result).toEqual({ data: partner });
+    expect(qb.update).toHaveBeenNthCalledWith(1, { partner_id: 2 });
+    expect(qb.update).toHaveBeenNthCalledWith(2, { partner_id: 1 });
+  });
+
+  test('returns error when partner not found', async () => {
+    const qb: any = supabase.from('profiles');
+    qb.single.mockResolvedValueOnce({ data: null, error: 'not found' });
+
+    const result = await connectByCode('CODE123', 'user1');
+    expect(result).toEqual({ error: 'Partner not found. Please check the code.' });
+    expect(qb.update).not.toHaveBeenCalled();
+  });
+
+  test('prevents double pairing when current user already paired', async () => {
+    const qb: any = supabase.from('profiles');
+    qb.single
+      .mockResolvedValueOnce({
+        data: { id: 2, user_id: 'user2', name: 'User2', partner_id: null },
+        error: null,
+      })
+      .mockResolvedValueOnce({ data: { id: 1, partner_id: 99 }, error: null });
+
+    const result = await connectByCode('CODE123', 'user1');
+    expect(result).toEqual({ error: 'User already paired' });
+    expect(qb.update).not.toHaveBeenCalled();
+  });
+
+  test('prevents double pairing when partner already paired', async () => {
+    const qb: any = supabase.from('profiles');
+    qb.single
+      .mockResolvedValueOnce({
+        data: { id: 2, user_id: 'user2', name: 'User2', partner_id: 99 },
+        error: null,
+      })
+      .mockResolvedValueOnce({ data: { id: 1, partner_id: null }, error: null });
+
+    const result = await connectByCode('CODE123', 'user1');
+    expect(result).toEqual({ error: 'User already paired' });
+    expect(qb.update).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add sign up test to ensure profile data and redirect passed to Supabase
- add connectByCode tests covering success, missing profile, and conflicting partner IDs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891e1ac6dc08331914e60de6ed980a2