### PR TITLE
feat: improve auth redirect handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,5 @@ EXPO_PUBLIC_SUPABASE_KEY=
 EXPO_PUBLIC_VAPID_PUBLIC_KEY=
 # Token used to authorize Supabase functions
 CRON_AUTH_TOKEN=
+# Public URL of the application used for redirects when window is unavailable
+EXPO_PUBLIC_SITE_URL=

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you want to work locally using your own IDE, you can clone this repo and push
 
 The only requirement is having Node.js & npm installed - [install with nvm](https://github.com/nvm-sh/nvm#installing-and-updating)
 
-Before running the app, create a `.env` file from `.env.example` and set `EXPO_PUBLIC_SUPABASE_URL` and `EXPO_PUBLIC_SUPABASE_KEY` with your Supabase project credentials. You should also set `CRON_AUTH_TOKEN` to a secret value and include it in an `Authorization: Bearer` header when calling protected Supabase functions.
+Before running the app, create a `.env` file from `.env.example` and set `EXPO_PUBLIC_SUPABASE_URL` and `EXPO_PUBLIC_SUPABASE_KEY` with your Supabase project credentials. You should also set `EXPO_PUBLIC_SITE_URL` to the public URL of your application and `CRON_AUTH_TOKEN` to a secret value and include it in an `Authorization: Bearer` header when calling protected Supabase functions.
 
 Follow these steps:
 

--- a/src/components/auth/auth-card.tsx
+++ b/src/components/auth/auth-card.tsx
@@ -10,7 +10,7 @@ import { useNavigate } from 'react-router-dom';
 import { useToast } from '@/hooks/use-toast';
 import { useTranslation } from '@/i18n';
 import { supabase } from '@/integrations/supabase/client';
-import { useTranslation } from '@/i18n';
+import { SITE_URL } from '@/config';
  codex/add-translation-keys-and-localize-strings
 
 
@@ -63,10 +63,12 @@ export const AuthCard: React.FC<AuthCardProps> = ({ mode, onModeChange, classNam
   const handleOAuthLogin = async (provider: 'google' | 'apple') => {
     setIsLoading(true);
     try {
+      const origin =
+        typeof window !== 'undefined' ? window.location.origin : SITE_URL;
       const { error } = await supabase.auth.signInWithOAuth({
         provider,
         options: {
-          redirectTo: `${window.location.origin}/dashboard`
+          ...(origin ? { redirectTo: `${origin}/dashboard` } : {})
         }
       });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,6 @@
 export const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL as string;
 export const SUPABASE_KEY = process.env.EXPO_PUBLIC_SUPABASE_KEY as string;
 export const VAPID_PUBLIC_KEY = process.env.EXPO_PUBLIC_VAPID_PUBLIC_KEY as string;
+export const SITE_URL = process.env.EXPO_PUBLIC_SITE_URL as string | undefined;
 export const NODE_ENV = process.env.NODE_ENV;
 export const isDevelopment = NODE_ENV === 'development';

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -19,7 +19,13 @@ interface AuthContextType {
   user: User | null;
   isLoading: boolean;
   signIn: (email: string, password: string) => Promise<boolean>;
-  signUp: (name: string, email: string, password: string, birthdate?: string) => Promise<boolean>;
+  signUp: (
+    name: string,
+    email: string,
+    password: string,
+    birthdate?: string,
+    redirectUrl?: string
+  ) => Promise<boolean>;
   connectPartner: (partnerEmail: string) => Promise<boolean>;
   connectByCode: (code: string) => Promise<boolean>;
   logout: () => void;
@@ -128,10 +134,25 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   };
 
-  const signUp = async (name: string, email: string, password: string, birthdate?: string): Promise<boolean> => {
+  const signUp = async (
+    name: string,
+    email: string,
+    password: string,
+    birthdate?: string,
+    redirectUrl?: string
+  ): Promise<boolean> => {
     setIsLoading(true);
     try {
-      const { error } = await authService.signUp(name, email, password, birthdate);
+      const url =
+        redirectUrl ??
+        (typeof window !== 'undefined' ? `${window.location.origin}/` : undefined);
+      const { error } = await authService.signUp(
+        name,
+        email,
+        password,
+        birthdate,
+        url
+      );
       if (error) {
         toast({
           title: 'Registration failed',

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,18 +1,25 @@
 import { supabase } from '@/integrations/supabase/client';
 import { withRetry } from '@/lib/retry';
+import { SITE_URL } from '@/config';
 
 export const signIn = (email: string, password: string) => {
   return withRetry(() => supabase.auth.signInWithPassword({ email, password }));
 };
 
-export const signUp = (name: string, email: string, password: string, birthdate?: string) => {
-  const redirectUrl = `${window.location.origin}/`;
+export const signUp = (
+  name: string,
+  email: string,
+  password: string,
+  birthdate?: string,
+  redirectUrl?: string
+) => {
+  const url = redirectUrl ?? SITE_URL;
   return withRetry(() =>
     supabase.auth.signUp({
       email,
       password,
       options: {
-        emailRedirectTo: redirectUrl,
+        ...(url ? { emailRedirectTo: url } : {}),
         data: { name, birthdate }
       }
     })


### PR DESCRIPTION
## Summary
- support configuration-based auth redirect URLs and optional override
- guard browser-only logic when computing OAuth redirects
- document new EXPO_PUBLIC_SITE_URL environment variable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891e196dfb8833184ae2ad6dfe11cfe