### PR TITLE
test: update auth tests

### DIFF
--- a/src/services/auth.test.ts
+++ b/src/services/auth.test.ts
@@ -4,11 +4,9 @@ vi.mock('@/lib/retry', () => ({
   withRetry: (fn: any) => fn(),
 }));
 
- 4ynwu2-codex/create-shared-helper-for-profile-management
-import { signIn, connectPartner, connectByCode } from './auth';
+vi.mock('@/config', () => ({ SITE_URL: 'https://example.com' }));
 
 import { signIn, signUp, connectPartner, connectByCode } from './auth';
- main
 import { supabase } from '@/integrations/supabase/client';
 
 test('signIn calls supabase auth method', async () => {
@@ -25,7 +23,26 @@ test('signUp calls supabase auth method with profile data', async () => {
     email: 'new@example.com',
     password: 'secret',
     options: {
-      emailRedirectTo: `${window.location.origin}/`,
+      emailRedirectTo: 'https://example.com',
+      data: { name: 'Test User', birthdate: '2000-01-01' },
+    },
+  });
+});
+
+test('signUp uses provided redirect URL when specified', async () => {
+  supabase.auth.signUp.mockClear();
+  await signUp(
+    'Test User',
+    'new@example.com',
+    'secret',
+    '2000-01-01',
+    'https://redirect.com'
+  );
+  expect(supabase.auth.signUp).toHaveBeenCalledWith({
+    email: 'new@example.com',
+    password: 'secret',
+    options: {
+      emailRedirectTo: 'https://redirect.com',
       data: { name: 'Test User', birthdate: '2000-01-01' },
     },
   });


### PR DESCRIPTION
## Summary
- clean up auth test imports and stray text
- verify signUp uses SITE_URL or provided redirect

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891fea809f483318a9b39454197dcc3