### PR TITLE
chore: clean up FAQ translation init

### DIFF
--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -19,11 +19,7 @@ const FAQ: React.FC = () => {
   const [items, setItems] = useState<FAQItem[]>([]);
   const [showOfflineForm, setShowOfflineForm] = useState(false);
   const [message, setMessage] = useState('');
- codex/add-certified-sexologists-link
-  const { t } = useTranslation();
-
-  const { lang } = useTranslation();
- main
+  const { t, lang } = useTranslation();
 
   useEffect(() => {
     const loadFAQ = async () => {


### PR DESCRIPTION
## Summary
- clean up leftover merge lines and consolidate translation hook in FAQ page

## Testing
- `npm test` *(fails: Syntax error "y" at src/services/auth.test.ts:7:2)*
- `npm run lint` *(fails: Parsing error in src/services/auth.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6891fea6090483318d946f2e74c1219b