### PR TITLE
chore(auth): remove stray lines from auth card

### DIFF
--- a/src/components/auth/auth-card.tsx
+++ b/src/components/auth/auth-card.tsx
@@ -11,8 +11,6 @@ import { useToast } from '@/hooks/use-toast';
 import { useTranslation } from '@/i18n';
 import { supabase } from '@/integrations/supabase/client';
 import { SITE_URL } from '@/config';
- codex/add-translation-keys-and-localize-strings
-
 
 const EU_COUNTRIES = [
   'AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR', 'HU',
@@ -31,7 +29,6 @@ const calculateAge = (birthdate: string) => {
   }
   return age;
 };
- main
 
 interface AuthCardProps {
   mode: 'login' | 'register' | 'connect';
@@ -95,7 +92,7 @@ export const AuthCard: React.FC<AuthCardProps> = ({ mode, onModeChange, classNam
         case 'login':
           success = await signIn(formData.email, formData.password);
           break;
-        case 'register':
+        case 'register': {
           if (formData.password !== formData.confirmPassword) {
             alert('Passwords do not match');
             return;
@@ -112,6 +109,7 @@ export const AuthCard: React.FC<AuthCardProps> = ({ mode, onModeChange, classNam
           }
           success = await signUp(formData.name, formData.email, formData.password, formData.birthdate);
           break;
+        }
         case 'connect':
           success = await connectPartner(formData.partnerEmail);
           break;


### PR DESCRIPTION
## Summary
- clean up stray placeholder strings around imports in `AuthCard`
- brace register case to satisfy ESLint

## Testing
- `npm test` *(fails: Syntax error in src/services/auth.test.ts)*
- `npm run lint` *(fails: lint errors in src/lib/csv.test.ts, src/pages/faq.tsx, src/services/auth.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6891fe9d7fd88331bb75356c8b45575e