### PR TITLE
chore: remove stray tokens and duplicate support button

### DIFF
--- a/src/components/auth/auth-card.tsx
+++ b/src/components/auth/auth-card.tsx
@@ -11,9 +11,6 @@ import { useToast } from '@/hooks/use-toast';
 import { useTranslation } from '@/i18n';
 import { supabase } from '@/integrations/supabase/client';
 import { SITE_URL } from '@/config';
- codex/add-translation-keys-and-localize-strings
-
-
 const EU_COUNTRIES = [
   'AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR', 'HU',
   'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL', 'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE'
@@ -31,7 +28,6 @@ const calculateAge = (birthdate: string) => {
   }
   return age;
 };
- main
 
 interface AuthCardProps {
   mode: 'login' | 'register' | 'connect';

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -19,11 +19,9 @@ const FAQ: React.FC = () => {
   const [items, setItems] = useState<FAQItem[]>([]);
   const [showOfflineForm, setShowOfflineForm] = useState(false);
   const [message, setMessage] = useState('');
- codex/add-certified-sexologists-link
   const { t } = useTranslation();
 
   const { lang } = useTranslation();
- main
 
   useEffect(() => {
     const loadFAQ = async () => {

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -861,11 +861,6 @@ const Settings: React.FC = () => {
                   <div className="flex flex-col sm:flex-row gap-2">
                     <PulseButton asChild variant="ghost" size="sm">
                       <Link to="/faq">{t('helpCenter')}</Link>
- codex/add-translation-keys-and-localize-strings
-                    </PulseButton>
-                    <PulseButton asChild variant="ghost" size="sm">
-                      <Link to="/contact">{t('contactSupport')}</Link>
-
                     </PulseButton>
                     <PulseButton asChild variant="ghost" size="sm">
                       <Link to="/contact">{t('contactSupport')}</Link>
@@ -878,7 +873,6 @@ const Settings: React.FC = () => {
                       >
                         {t('proResources')}
                       </a>
- main
                     </PulseButton>
                   </div>
                 </div>

--- a/src/services/auth.test.ts
+++ b/src/services/auth.test.ts
@@ -4,11 +4,8 @@ vi.mock('@/lib/retry', () => ({
   withRetry: (fn: any) => fn(),
 }));
 
- 4ynwu2-codex/create-shared-helper-for-profile-management
-import { signIn, connectPartner, connectByCode } from './auth';
-
 import { signIn, signUp, connectPartner, connectByCode } from './auth';
- main
+
 import { supabase } from '@/integrations/supabase/client';
 
 test('signIn calls supabase auth method', async () => {


### PR DESCRIPTION
## Summary
- remove stray codex placeholders across faq, auth card, and auth tests
- clean settings help section and drop duplicate Contact Support button

## Testing
- `npm test` *(fails: expected spy to be called with emailRedirectTo)*
- `npm run lint` *(fails: unexpected any type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6891fe99cdec8331989665ea505f1376