### PR TITLE
feat: allow scheduling surprises

### DIFF
--- a/public/surprise-ideas.json
+++ b/public/surprise-ideas.json
@@ -28,5 +28,15 @@
   "Make a time capsule",
   "Try geocaching",
   "Have a karaoke night",
-  "Prepare breakfast in bed"
+  "Prepare breakfast in bed",
+  "Take a cooking class",
+  "Attend a local concert",
+  "Plan a surprise spa day",
+  "Write each other poems",
+  "Do a puzzle together",
+  "Take a bike ride",
+  "Explore a new hiking trail",
+  "Make homemade pizza",
+  "Watch old home videos",
+  "Plan a themed costume night"
 ]

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -145,6 +145,30 @@ export type Database = {
         }
         Relationships: []
       },
+      scheduled_surprises: {
+        Row: {
+          id: string
+          user_id: string
+          idea: string
+          scheduled_at: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          idea: string
+          scheduled_at: string
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          idea?: string
+          scheduled_at?: string
+          created_at?: string
+        }
+        Relationships: []
+      },
       time_slots: {
         Row: {
           id: string

--- a/src/lib/reminders.ts
+++ b/src/lib/reminders.ts
@@ -18,3 +18,33 @@ export const scheduleReminder = async (userId: string, slot: ReminderSlot) => {
     })
   );
 };
+
+export const scheduleSurprise = async (
+  userId: string,
+  idea: string,
+  dateTime: string
+) => {
+  const isoDate = new Date(dateTime).toISOString();
+  const { data } = await withRetry(() =>
+    supabase
+      .from('scheduled_surprises')
+      .insert({
+        user_id: userId,
+        idea,
+        scheduled_at: isoDate,
+      })
+      .select()
+      .single()
+  );
+
+  if (data) {
+    const remindAt = new Date(new Date(isoDate).getTime() - 2 * 60 * 60 * 1000);
+    await withRetry(() =>
+      supabase.from('reminders').insert({
+        user_id: userId,
+        time_slot_id: data.id,
+        remind_at: remindAt.toISOString(),
+      })
+    );
+  }
+};

--- a/supabase/migrations/20250801030000-add-scheduled-surprises.sql
+++ b/supabase/migrations/20250801030000-add-scheduled-surprises.sql
@@ -1,0 +1,18 @@
+-- Create scheduled_surprises table
+CREATE TABLE public.scheduled_surprises (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  idea TEXT NOT NULL,
+  scheduled_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Enable Row Level Security
+ALTER TABLE public.scheduled_surprises ENABLE ROW LEVEL SECURITY;
+
+-- RLS policy: users manage their scheduled surprises
+CREATE POLICY "Users can manage their scheduled surprises"
+ON public.scheduled_surprises
+FOR ALL
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add ability to schedule surprise ideas with a date/time picker
- persist scheduled surprises and reminders in Supabase
- expand surprise ideas library with more suggestions

## Testing
- `npm run lint` *(fails: Unexpected any in src/services/auth.test.ts)*
- `npm test` *(fails: ReferenceError: codex is not defined)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68921ed3baac833190a44975e790a83f