### PR TITLE
feat: add pulse customization settings

### DIFF
--- a/src/components/dashboard/central-pulse-button.tsx
+++ b/src/components/dashboard/central-pulse-button.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import { Heart, Check } from 'lucide-react';
-import { supabase } from '@/integrations/supabase/client';
+import { Check } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
+import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { useTranslation } from '@/i18n';
 import { cn } from '@/lib/utils';
@@ -73,7 +73,7 @@ export const CentralPulseButton: React.FC<CentralPulseButtonProps> = ({ classNam
       console.error('Error checking partner availability:', err);
     }
 
-    navigator.vibrate?.(50);
+    navigator.vibrate?.(user?.pulseVibration || 50);
 
     setState('sending');
 
@@ -97,23 +97,28 @@ export const CentralPulseButton: React.FC<CentralPulseButtonProps> = ({ classNam
     }, 1000);
   };
 
+  const pulseSymbol = user?.secretPulse
+    ? user?.secretPulseIcon || '❔'
+    : user?.pulseEmoji || '❤️';
+
   return (
     <button
       aria-label="Send Pulse"
       onClick={handleClick}
       className={cn(
-        'relative w-16 h-16 rounded-full flex items-center justify-center bg-gradient-primary text-primary-foreground shadow-glow',
+        'relative w-16 h-16 rounded-full flex items-center justify-center text-primary-foreground shadow-glow',
         state === 'sending' && 'animate-pulse',
         className
       )}
+      style={{ backgroundColor: user?.pulseColor || '#ff0066' }}
     >
       {state === 'sending' && (
-        <span className="pointer-events-none absolute inset-0 rounded-full bg-primary/40 animate-ping" />
+        <span className="pointer-events-none absolute inset-0 rounded-full opacity-40 animate-ping" style={{ backgroundColor: user?.pulseColor || '#ff0066' }} />
       )}
       {state === 'sent' ? (
         <Check className="w-8 h-8" />
       ) : (
-        <Heart className="w-8 h-8" />
+        <span className="text-3xl leading-none">{pulseSymbol}</span>
       )}
     </button>
   );

--- a/src/components/messaging/message-center.tsx
+++ b/src/components/messaging/message-center.tsx
@@ -16,7 +16,7 @@ import { useMessages } from '@/hooks/use-messages';
 interface Message {
   id: string;
   content: string;
-  type: 'text' | 'emoji';
+  type: 'text' | 'emoji' | 'pulse';
   sender_id: string;
   receiver_id: string;
   created_at: string;
@@ -27,7 +27,7 @@ interface Message {
 interface DatabaseMessage {
   id: string;
   content: string;
-  type: 'text' | 'emoji';
+  type: 'text' | 'emoji' | 'pulse';
   sender_id: string;
   receiver_id: string;
   created_at: string;
@@ -36,9 +36,13 @@ interface DatabaseMessage {
 
 interface MessageCenterProps {
   className?: string;
+  pulseEmoji?: string;
+  pulseColor?: string;
+  secretPulse?: boolean;
+  secretPulseIcon?: string;
 }
 
-export const MessageCenter: React.FC<MessageCenterProps> = ({ className }) => {
+export const MessageCenter: React.FC<MessageCenterProps> = ({ className, pulseEmoji, pulseColor, secretPulse, secretPulseIcon }) => {
   const { user } = useAuth();
   const { toast } = useToast();
   const { t } = useTranslation();
@@ -61,6 +65,10 @@ export const MessageCenter: React.FC<MessageCenterProps> = ({ className }) => {
       }))
       .reverse();
   }, [data, user]);
+  const pulseDisplayEmoji = pulseEmoji ?? user?.pulseEmoji ?? '❤️';
+  const pulseDisplayColor = pulseColor ?? user?.pulseColor ?? '#ff0066';
+  const pulseSecret = secretPulse ?? user?.secretPulse ?? false;
+  const pulseSecretIcon = secretPulseIcon ?? user?.secretPulseIcon ?? '❔';
   const now = new Date();
   const isSnoozed = user?.snoozeUntil && new Date(user.snoozeUntil) > now;
   const partnerSnoozed = user?.partnerSnoozeUntil && new Date(user.partnerSnoozeUntil) > now;
@@ -430,6 +438,10 @@ export const MessageCenter: React.FC<MessageCenterProps> = ({ className }) => {
                     >
                       {message.type === 'emoji' ? (
                         <div className="text-2xl">{message.content}</div>
+                      ) : message.type === 'pulse' ? (
+                        <div className="text-2xl" style={{ color: pulseDisplayColor }}>
+                          {pulseSecret ? pulseSecretIcon : pulseDisplayEmoji}
+                        </div>
                       ) : (
                         <p className="text-sm">{message.content}</p>
                       )}

--- a/src/components/ui/pulse-button.tsx
+++ b/src/components/ui/pulse-button.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { TouchableOpacity, Text, StyleSheet, TouchableOpacityProps, ViewStyle, TextStyle } from 'react-native';
+import { useAuth } from '@/contexts/AuthContext';
 
 export type PulseButtonVariant = 'pulse' | 'ghost' | 'soft' | 'intimate';
 export type PulseButtonSize = 'default' | 'sm' | 'lg' | 'xl';
@@ -14,9 +15,16 @@ export interface PulseButtonProps extends TouchableOpacityProps {
 
 const PulseButton = React.forwardRef<TouchableOpacity, PulseButtonProps>(
   ({ variant = 'pulse', size = 'default', style, children, asChild, ...props }, ref) => {
+    const { user } = useAuth();
+
+    const variantStyle: ViewStyle =
+      variant === 'pulse'
+        ? { ...styles.pulse, backgroundColor: user?.pulseColor || styles.pulse.backgroundColor }
+        : (styles as Record<string, ViewStyle>)[variant];
+
     const buttonStyle: ViewStyle[] = [
       styles.base,
-      styles[variant],
+      variantStyle,
       styles[size],
     ];
 
@@ -26,12 +34,22 @@ const PulseButton = React.forwardRef<TouchableOpacity, PulseButtonProps>(
       textStyle.push(styles.textGhost);
     }
 
+    let content: React.ReactNode = children;
+    if (variant === 'pulse') {
+      if (!content) {
+        content = user?.pulseEmoji || '❤️';
+      }
+      if (user?.secretPulse) {
+        content = user.secretPulseIcon || '❔';
+      }
+    }
+
     return (
       <TouchableOpacity ref={ref} style={[...buttonStyle, style]} {...props}>
-        {typeof children === 'string' ? (
-          <Text style={textStyle}>{children}</Text>
+        {typeof content === 'string' ? (
+          <Text style={textStyle}>{content}</Text>
         ) : (
-          children
+          content
         )}
       </TouchableOpacity>
     );

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -13,6 +13,11 @@ interface User {
   snoozeUntil?: string | null;
   partnerSnoozeUntil?: string | null;
   isPremium?: boolean;
+  pulseEmoji?: string | null;
+  pulseColor?: string | null;
+  pulseVibration?: number | null;
+  secretPulse?: boolean | null;
+  secretPulseIcon?: string | null;
 }
 
 interface AuthContextType {
@@ -91,7 +96,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           partnerName: profile.partner?.name,
           snoozeUntil: profile.snooze_until,
           partnerSnoozeUntil: profile.partner?.snooze_until,
-          isPremium: profile.is_premium
+          isPremium: profile.is_premium,
+          pulseEmoji: profile.pulse_emoji,
+          pulseColor: profile.pulse_color,
+          pulseVibration: profile.pulse_vibration,
+          secretPulse: profile.secret_pulse,
+          secretPulseIcon: profile.secret_pulse_icon
         });
       }
     } catch (error) {

--- a/src/hooks/use-toast-notification.ts
+++ b/src/hooks/use-toast-notification.ts
@@ -1,4 +1,5 @@
 import { useToast } from '@/hooks/use-toast';
+import { useAuth } from '@/contexts/AuthContext';
 
 interface ToastNotificationOptions {
   title: string;
@@ -9,6 +10,7 @@ interface ToastNotificationOptions {
 
 export const useToastNotification = () => {
   const { toast } = useToast();
+  const { user } = useAuth();
 
   const showSuccess = (message: string, description?: string) => {
     toast({
@@ -32,8 +34,11 @@ export const useToastNotification = () => {
 
   // Simulate receiving notifications from partner
   const simulatePartnerNotification = () => {
+    const pulseIcon = user?.secretPulse
+      ? user?.secretPulseIcon || '🔔'
+      : user?.pulseEmoji || '💕';
     const notifications = [
-      { title: "💕 New pulse from Alex", description: "Your partner sent you a heart!" },
+      { title: `${pulseIcon} New pulse from Alex`, description: "Your partner sent you a heart!" },
       { title: "📅 Calendar reminder", description: "Date night in 30 minutes" },
       { title: "💬 New message", description: "Alex: Can't wait to see you tonight!" },
     ];

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -55,6 +55,11 @@ export type Database = {
           partner_id: string | null
           snooze_until: string | null
           use_face_id: boolean | null
+          pulse_emoji: string | null
+          pulse_color: string | null
+          pulse_vibration: number | null
+          secret_pulse: boolean | null
+          secret_pulse_icon: string | null
           updated_at: string
           user_id: string
         }
@@ -68,6 +73,11 @@ export type Database = {
           partner_id?: string | null
           snooze_until?: string | null
           use_face_id?: boolean | null
+          pulse_emoji?: string | null
+          pulse_color?: string | null
+          pulse_vibration?: number | null
+          secret_pulse?: boolean | null
+          secret_pulse_icon?: string | null
           updated_at?: string
           user_id: string
         }
@@ -81,6 +91,11 @@ export type Database = {
           partner_id?: string | null
           snooze_until?: string | null
           use_face_id?: boolean | null
+          pulse_emoji?: string | null
+          pulse_color?: string | null
+          pulse_vibration?: number | null
+          secret_pulse?: boolean | null
+          secret_pulse_icon?: string | null
           updated_at?: string
           user_id?: string
         }

--- a/src/pages/messages.tsx
+++ b/src/pages/messages.tsx
@@ -5,9 +5,11 @@ import { PulseButton } from '@/components/ui/pulse-button';
 import { ArrowLeft } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import logger from '@/lib/logger';
+import { useAuth } from '@/contexts/AuthContext';
 
 const Messages: React.FC = () => {
   const navigate = useNavigate();
+  const { user } = useAuth();
 
   const handleEmojiSend = (emoji: string, category: string) => {
     logger.info('Sending emoji:', emoji, 'from category:', category);
@@ -37,7 +39,12 @@ const Messages: React.FC = () => {
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           {/* Main Message Center */}
           <div className="lg:col-span-2">
-            <MessageCenter />
+            <MessageCenter
+              pulseEmoji={user?.pulseEmoji}
+              pulseColor={user?.pulseColor}
+              secretPulse={user?.secretPulse}
+              secretPulseIcon={user?.secretPulseIcon}
+            />
           </div>
 
           {/* Emoji Picker Sidebar */}

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -65,6 +65,13 @@ interface SettingsData {
     autoDelete30d: boolean;
   };
   theme: 'light' | 'dark' | 'auto';
+  pulse: {
+    emoji: string;
+    color: string;
+    vibration: number;
+    secret: boolean;
+    secretIcon: string;
+  };
 }
 
 const Settings: React.FC = () => {
@@ -104,6 +111,13 @@ const Settings: React.FC = () => {
       autoDelete30d: false,
     },
     theme: 'light',
+    pulse: {
+      emoji: user?.pulseEmoji || '❤️',
+      color: user?.pulseColor || '#ff0066',
+      vibration: user?.pulseVibration ?? 50,
+      secret: user?.secretPulse || false,
+      secretIcon: user?.secretPulseIcon || '❔',
+    },
   });
 
   const [activeSection, setActiveSection] = useState<'profile' | 'notifications' | 'privacy' | 'general' | 'help'>('profile');
@@ -123,7 +137,7 @@ const Settings: React.FC = () => {
       if (!user) return;
       const { data, error } = await supabase
         .from('profiles')
-        .select('name, email, bio, avatar, use_face_id')
+        .select('name, email, bio, avatar, use_face_id, pulse_emoji, pulse_color, pulse_vibration, secret_pulse, secret_pulse_icon')
         .eq('user_id', user.id)
         .single();
 
@@ -145,6 +159,13 @@ const Settings: React.FC = () => {
             ...prev.privacy,
             useFaceID: profile.use_face_id ?? false,
           },
+          pulse: {
+            emoji: profile.pulse_emoji || '❤️',
+            color: profile.pulse_color || '#ff0066',
+            vibration: profile.pulse_vibration ?? 50,
+            secret: profile.secret_pulse ?? false,
+            secretIcon: profile.secret_pulse_icon || '❔',
+          },
         }));
       }
     };
@@ -154,11 +175,24 @@ const Settings: React.FC = () => {
 
   const saveSettings = async () => {
     if (!user) return;
-    const updates: TablesUpdate<'profiles'> & { bio?: string; avatar?: string } = {
+    const updates: TablesUpdate<'profiles'> & {
+      bio?: string;
+      avatar?: string;
+      pulse_emoji?: string;
+      pulse_color?: string;
+      pulse_vibration?: number;
+      secret_pulse?: boolean;
+      secret_pulse_icon?: string;
+    } = {
       name: settings.name,
       email: settings.email,
       bio: settings.bio,
       avatar: settings.avatar,
+      pulse_emoji: settings.pulse.emoji,
+      pulse_color: settings.pulse.color,
+      pulse_vibration: settings.pulse.vibration,
+      secret_pulse: settings.pulse.secret,
+      secret_pulse_icon: settings.pulse.secretIcon,
     };
 
     const { error } = await supabase
@@ -746,6 +780,90 @@ const Settings: React.FC = () => {
               {activeSection === 'general' && (
                 <div className="space-y-6">
                   <div className="space-y-4">
+                    <div className="space-y-4">
+                      <h3 className="font-medium mb-1">Pulse Customization</h3>
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div>
+                          <Label>Emoji</Label>
+                          <Input
+                            value={settings.pulse.emoji}
+                            onChange={(e) =>
+                              setSettings({
+                                ...settings,
+                                pulse: { ...settings.pulse, emoji: e.target.value },
+                              })
+                            }
+                            className="w-20 text-center text-2xl"
+                          />
+                        </div>
+                        <div>
+                          <Label>Color</Label>
+                          <Input
+                            type="color"
+                            value={settings.pulse.color}
+                            onChange={(e) =>
+                              setSettings({
+                                ...settings,
+                                pulse: { ...settings.pulse, color: e.target.value },
+                              })
+                            }
+                          />
+                        </div>
+                        <div>
+                          <Label>Vibration (ms)</Label>
+                          <Input
+                            type="number"
+                            value={settings.pulse.vibration}
+                            onChange={(e) =>
+                              setSettings({
+                                ...settings,
+                                pulse: {
+                                  ...settings.pulse,
+                                  vibration: Number(e.target.value),
+                                },
+                              })
+                            }
+                            className="w-24"
+                          />
+                        </div>
+                        <div className="flex items-center justify-between col-span-1 sm:col-span-2">
+                          <div>
+                            <Label>Secret Pulse</Label>
+                            <p className="text-sm text-muted-foreground">
+                              Hide pulse visuals
+                            </p>
+                          </div>
+                          <Switch
+                            checked={settings.pulse.secret}
+                            onCheckedChange={(checked) =>
+                              setSettings({
+                                ...settings,
+                                pulse: { ...settings.pulse, secret: checked },
+                              })
+                            }
+                          />
+                        </div>
+                        <div>
+                          <Label>Secret Icon</Label>
+                          <Input
+                            value={settings.pulse.secretIcon}
+                            onChange={(e) =>
+                              setSettings({
+                                ...settings,
+                                pulse: {
+                                  ...settings.pulse,
+                                  secretIcon: e.target.value,
+                                },
+                              })
+                            }
+                            className="w-20 text-center text-2xl"
+                          />
+                        </div>
+                      </div>
+                    </div>
+
+                    <Separator />
+
                     <div className="flex items-center justify-between">
                       <div>
                         <h3 className="font-medium">Pulse History</h3>


### PR DESCRIPTION
## Summary
- allow users to customize pulse emoji, color, vibration and secret icon in settings
- render pulses with user preferences and hide visuals when secret mode is enabled
- store pulse preferences in profiles and use them for buttons, messages and notifications

## Testing
- `npm run build`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68921ed0d6908331a0056713ae1fd9b4