### PR TITLE
feat: integrate external calendars and energy-based suggestions

### DIFF
--- a/src/integrations/google-calendar.ts
+++ b/src/integrations/google-calendar.ts
@@ -1,0 +1,59 @@
+import type { TimeSlot } from '@/components/calendar/shared-calendar';
+
+const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+
+interface GoogleEvent {
+  id: string;
+  start: { dateTime?: string; date?: string };
+  end: { dateTime?: string; date?: string };
+  summary?: string;
+}
+
+function parseEvent(event: GoogleEvent): TimeSlot | null {
+  const start = event.start.dateTime || event.start.date;
+  const end = event.end.dateTime || event.end.date;
+  if (!start || !end) return null;
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+  return {
+    id: `google-${event.id}`,
+    user_id: 'external',
+    start: startDate.toISOString().slice(11,16),
+    end: endDate.toISOString().slice(11,16),
+    date: startDate.toISOString().slice(0,10),
+    type: 'booked',
+    title: event.summary || null,
+    source: 'google',
+  };
+}
+
+export async function fetchGoogleCalendarEvents(): Promise<TimeSlot[]> {
+  try {
+    const token: string | null = await new Promise((resolve) => {
+      const google: any = (window as any).google;
+      if (!google?.accounts?.oauth2) {
+        resolve(null);
+        return;
+      }
+      const client = google.accounts.oauth2.initTokenClient({
+        client_id: GOOGLE_CLIENT_ID,
+        scope: 'https://www.googleapis.com/auth/calendar.readonly',
+        callback: (resp: any) => resolve(resp.access_token),
+      });
+      client.requestAccessToken();
+    });
+    if (!token) return [];
+    const now = new Date();
+    const max = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+    const url = `https://www.googleapis.com/calendar/v3/calendars/primary/events?timeMin=${now.toISOString()}&timeMax=${max.toISOString()}`;
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const data = await res.json();
+    const items: GoogleEvent[] = data.items || [];
+    return items.map(parseEvent).filter(Boolean) as TimeSlot[];
+  } catch (err) {
+    console.error('Failed to fetch Google Calendar events', err);
+    return [];
+  }
+}

--- a/src/integrations/microsoft-calendar.ts
+++ b/src/integrations/microsoft-calendar.ts
@@ -1,0 +1,51 @@
+import type { TimeSlot } from '@/components/calendar/shared-calendar';
+
+const MICROSOFT_CLIENT_ID = import.meta.env.VITE_MICROSOFT_CLIENT_ID;
+
+interface MsEvent {
+  id: string;
+  subject?: string;
+  start: { dateTime: string };
+  end: { dateTime: string };
+}
+
+function parseEvent(event: MsEvent): TimeSlot {
+  const startDate = new Date(event.start.dateTime);
+  const endDate = new Date(event.end.dateTime);
+  return {
+    id: `microsoft-${event.id}`,
+    user_id: 'external',
+    start: startDate.toISOString().slice(11,16),
+    end: endDate.toISOString().slice(11,16),
+    date: startDate.toISOString().slice(0,10),
+    type: 'booked',
+    title: event.subject || null,
+    source: 'microsoft',
+  };
+}
+
+export async function fetchMicrosoftCalendarEvents(): Promise<TimeSlot[]> {
+  try {
+    const msal: any = (window as any).msal;
+    if (!msal?.PublicClientApplication) {
+      return [];
+    }
+    const app = new msal.PublicClientApplication({
+      auth: { clientId: MICROSOFT_CLIENT_ID, redirectUri: window.location.origin },
+    });
+    const login = await app.loginPopup({ scopes: ['Calendars.Read'] });
+    const tokenResp = await app.acquireTokenSilent({
+      scopes: ['Calendars.Read'],
+      account: login.account,
+    });
+    const res = await fetch('https://graph.microsoft.com/v1.0/me/events?$select=subject,start,end', {
+      headers: { Authorization: `Bearer ${tokenResp.accessToken}` },
+    });
+    const data = await res.json();
+    const items: MsEvent[] = data.value || [];
+    return items.map(parseEvent);
+  } catch (err) {
+    console.error('Failed to fetch Microsoft Calendar events', err);
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- add Google and Microsoft calendar OAuth integrations
- merge external calendar events and use wearable energy metrics for smarter suggestions
- drop weekly slot limits in shared calendar

## Testing
- `npm test` *(fails: ReferenceError: codex is not defined)*
- `npm run lint` *(fails: Unexpected any / unused expressions in auth.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68921ecff0188331b382bbbee0e0816d