### PR TITLE
chore: clean devDependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,13 +32,10 @@
     "@eslint/js": "^9.9.0",
     "@types/node": "^22.5.5",
     "@types/react": "^18.3.3",
- codex/configure-path-mapping-for-@/components
     "@types/react-dom": "^18.3.0",
     "@vitest/coverage-v8": "^3.2.4",
     "autoprefixer": "^10.4.20",
     "babel-plugin-module-resolver": "^5.0.2",
-
- main
     "eslint": "^9.9.0",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "globals": "^15.9.0",


### PR DESCRIPTION
## Summary
- remove stray devDependencies entries
## Testing
- `npm test` (fails: Error: Failed to resolve import "@testing-library/jest-dom" from "vitest.setup.ts". Does the file exist?)

------
https://chatgpt.com/codex/tasks/task_e_689321f5786883318a365bcf25882861