### PR TITLE
chore: ignore server files for snack build

### DIFF
--- a/.snackignore
+++ b/.snackignore
@@ -1,0 +1,6 @@
+# Directories not needed for Expo Snack demo
+supabase/
+**/migrations/
+docs/
+public/
+src/assets/


### PR DESCRIPTION
## Summary
- ignore backend, migrations and large assets for Expo Snack demo

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npx expo --version` *(fails: requires installing expo)*

------
https://chatgpt.com/codex/tasks/task_e_689321fa67cc8331b758b63cbc0dd5d0