### PR TITLE
fix(snack): remove breaking react-hooks plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "autoprefixer": "^10.4.20",
     "babel-plugin-module-resolver": "^5.0.2",
     "eslint": "^9.9.0",
-    "eslint-plugin-react-hooks": "^5.1.0-rc.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "globals": "^15.9.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1"


### PR DESCRIPTION
## Summary
- revert `eslint-plugin-react-hooks` to v4 to avoid crypto dependency

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68932d3c4f748331af497b483bdaffed