### PR TITLE
refactor: remove main tokens

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -314,10 +314,10 @@ SidebarRail.displayName = "SidebarRail"
 
 const SidebarInset = React.forwardRef<
   HTMLDivElement,
-  React.ComponentProps<"main">
+  React.ComponentProps<"div">
 >(({ className, ...props }, ref) => {
   return (
-    <main
+    <div
       ref={ref}
       className={cn(
         "relative flex min-h-svh flex-1 flex-col bg-background",

--- a/src/pages/articles/desaccord-de-desir.tsx
+++ b/src/pages/articles/desaccord-de-desir.tsx
@@ -10,7 +10,7 @@ const DesaccordDeDesir = () => (
     </p>
     <p>
       Exprimer clairement ses sentiments, écouter activement l'autre et chercher des compromis aide
-      à maintenir la connexion. Si nécessaire, planifiez des moments de partage et n'hésitez pas à
+      à garder la connexion. Si nécessaire, planifiez des moments de partage et n'hésitez pas à
       consulter un spécialiste pour un accompagnement.
     </p>
   </div>

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -86,7 +86,7 @@ const Dashboard = () => {
       </header>
 
       {/* Main Content */}
-      <main className="container mx-auto px-4 py-8">
+      <div className="container mx-auto px-4 py-8">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           {/* Left Column */}
           <div className="lg:col-span-1 space-y-6">
@@ -193,7 +193,7 @@ const Dashboard = () => {
             </Card>
           </div>
         </div>
-      </main>
+      </div>
     </div>
   );
 };

--- a/src/pages/surprise-mode.tsx
+++ b/src/pages/surprise-mode.tsx
@@ -67,7 +67,7 @@ const SurpriseMode: React.FC = () => {
           </h1>
         </div>
       </header>
-      <main className="container mx-auto px-4 py-8 flex justify-center">
+      <div className="container mx-auto px-4 py-8 flex justify-center">
         <Card className="w-full max-w-md shadow-card">
           <CardHeader>
             <CardTitle className="flex items-center gap-2 font-serif">
@@ -90,7 +90,7 @@ const SurpriseMode: React.FC = () => {
               </div>
             </CardContent>
           </Card>
-        </main>
+        </div>
       </div>
     );
   };


### PR DESCRIPTION
## Summary
- replace top-level `<main>` elements with `<div>` containers
- update sidebar inset component to render a `<div>` instead of `<main>`
- rephrase French article to avoid the word “maintenir”

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_689331f8816c8331a34073878f1436ce