### PR TITLE
chore: move react types to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@react-navigation/native-stack": "^7.3.24",
     "@supabase/supabase-js": "^2.52.0",
     "@tanstack/react-query": "^5.56.2",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
     "date-fns": "^3.6.0",
     "expo": "^53.0.20",
     "expo-device": "^7.1.4",
@@ -77,8 +79,6 @@
   "devDependencies": {
     "@eslint/js": "^9.9.0",
     "@types/node": "^22.5.5",
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
     "@vitest/coverage-v8": "^3.2.4",
     "autoprefixer": "^10.4.20",
     "babel-plugin-module-resolver": "^5.0.2",


### PR DESCRIPTION
## Summary
- move `@types/react` and `@types/react-dom` into dependencies

## Testing
- `npm install` *(fails: No matching version found for lovable-tagger@^0.1.1)*
- `npm run build`
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689353533fd8833184d7a206314a78a5