### PR TITLE
feat: add metro config alias

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,15 @@
+import { getDefaultConfig } from 'expo/metro-config';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const config = getDefaultConfig(__dirname);
+
+config.resolver.alias = {
+  ...(config.resolver.alias || {}),
+  '@': path.resolve(__dirname, 'src'),
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add metro config alias for @ paths

## Testing
- `npm run build`
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68935356a6408331bd8406e152f7f806