### PR TITLE
refactor: export named tailwind config constant

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 import type { Config } from "tailwindcss";
 import tailwindcssAnimate from "tailwindcss-animate";
 
-export default {
+const config: Config = {
 	darkMode: ["class"],
 	content: [
 		"./pages/**/*.{ts,tsx}",
@@ -139,4 +139,6 @@ export default {
 		}
 	},
         plugins: [tailwindcssAnimate],
-} satisfies Config;
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- define typed Tailwind `config` constant and export it

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_6893684504bc8331bf92b50ed1509192