### PR TITLE
refactor: convert babel config to commonjs

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,4 @@
-export default function (api) {
+module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
@@ -14,4 +14,4 @@ export default function (api) {
       ],
     ],
   };
-}
+};


### PR DESCRIPTION
## Summary
- refactor babel.config.js to use `module.exports = function (api) { ... }`
- retain `module-resolver` plugin with `@` alias pointing to `./src`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689369abab8083319a4a35abb5d07ccb