### PR TITLE
refactor: define vitest config constant

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,18 +1,20 @@
-import { defineConfig } from 'vitest/config';
-import path from 'path';
+import path from "path";
+import type { UserConfig as Config } from "vitest/config";
 
-export default defineConfig({
+const config: Config = {
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, 'src'),
+      "@": path.resolve(__dirname, "src"),
     },
   },
   test: {
-    environment: 'jsdom',
+    environment: "jsdom",
     globals: true,
-    setupFiles: './vitest.setup.ts',
+    setupFiles: "./vitest.setup.ts",
     coverage: {
-      reporter: ['text', 'lcov'],
+      reporter: ["text", "lcov"],
     },
   },
-});
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- define and export a typed vitest config constant

## Testing
- `npm run lint` *(fails: Unexpected any from existing code)*
- `npm test` *(fails: Cannot find module '@testing-library/dom')*

------
https://chatgpt.com/codex/tasks/task_e_689369ae664c83318599e193593965a7