### PR TITLE
chore: ignore config and test files in Snack build

### DIFF
--- a/.snackignore
+++ b/.snackignore
@@ -4,3 +4,20 @@ supabase/
 docs/
 public/
 src/assets/
+
+# Config and test files not needed for Expo Snack demo
+babel.config.js
+capacitor.config.json
+components.json
+eslint.config.js
+metro.config.js
+postcss.config.js
+tailwind.config.ts
+tsconfig.json
+tsconfig.app.json
+vite.config.ts
+vitest.config.ts
+vitest.setup.ts
+package-lock.json
+**/*.test.*
+**/*.spec.*


### PR DESCRIPTION
## Summary
- exclude config and test artifacts from Snack uploads by expanding `.snackignore`
- ensure Snack packages contain only runtime code

## Testing
- `npm test`
- `node -e "const fs=require('fs');const ignore=require('ignore');const ig=ignore().add(fs.readFileSync('.snackignore','utf8'));const files=fs.readFileSync('all_files.txt','utf8').trim().split('\n');console.log(files.filter(f=>!ig.ignores(f)).join('\n'))" > snack_files.txt`
- `grep -E 'vitest.config.ts|tailwind.config.ts|Hello.test.tsx|babel.config.js' snack_files.txt`
- `grep -E '^docs/' snack_files.txt`
- `grep -E '^public/' snack_files.txt`


------
https://chatgpt.com/codex/tasks/task_e_689369acc6dc8331963ff929052139ef