### PR TITLE
chore: move react type packages to dev deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "expo-notifications": "^0.31.4",
         "input-otp": "^1.1.4",
         "lucide-react": "^0.441.0",
-        "next-themes": "^0.2.1",
         "papaparse": "^5.4.1",
         "qrcode.react": "^3.1.0",
         "react": "^18.3.1",
@@ -14531,17 +14530,6 @@
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.0.1.tgz",
       "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==",
       "license": "MIT"
-    },
-    "node_modules/next-themes": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.2.1.tgz",
-      "integrity": "sha512-B+AKNfYNIzh0vqQQKqQItTS8evEouKD7H5Hj3kmuPERwddR2TxvDSFZuTj6T7Jfn1oyeUyJMydPl1Bkxkh0W7A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "next": "*",
-        "react": "*",
-        "react-dom": "*"
-      }
     },
     "node_modules/nocache": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
     "@react-navigation/native-stack": "^7.3.24",
     "@supabase/supabase-js": "^2.52.0",
     "@tanstack/react-query": "^5.56.2",
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0",
     "date-fns": "^3.6.0",
     "expo": "^53.0.20",
     "expo-constants": "~17.1.7",
@@ -81,6 +79,8 @@
   "devDependencies": {
     "@eslint/js": "^9.9.0",
     "@types/node": "^22.5.5",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
     "@vitest/coverage-v8": "^3.2.4",
     "autoprefixer": "^10.4.20",
     "babel-plugin-module-resolver": "^5.0.2",


### PR DESCRIPTION
## Summary
- move @types/react and @types/react-dom to devDependencies
- update lockfile

## Testing
- `npm install --legacy-peer-deps`
- `npm test` *(fails: Cannot find package 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_689369a6a1e08331805fa9c2f0f8490e