### PR TITLE
fix: clean package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
- codex/add-expo/metro-config-to-devdependencies
 
     "@react-native-async-storage/async-storage": "1.23.1",
     "@react-navigation/native": "^7.1.17",
@@ -32,7 +31,6 @@
     "react-native-screens": "~4.4.0",
     "react-native-url-polyfill": "^2.0.0",
     "zod": "^3.23.8",
- main
     "@radix-ui/react-accordion": "^1.0.0",
     "@radix-ui/react-alert-dialog": "^1.0.0",
     "@radix-ui/react-aspect-ratio": "^1.0.0",
@@ -104,12 +102,10 @@
     "@testing-library/jest-dom": "^6.2.1",
     "@testing-library/react": "^16.0.0",
     "@types/node": "^22.5.5",
- codex/add-expo/metro-config-to-devdependencies
     "@vitejs/plugin-react-swc": "^3.5.0",
 
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
- main
     "@vitest/coverage-v8": "^3.2.4",
     "autoprefixer": "^10.4.20",
     "babel-plugin-module-resolver": "^5.0.2",
@@ -118,14 +114,13 @@
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.6",
     "globals": "^15.9.0",
- codex/add-expo/metro-config-to-devdependencies
     "lovable-tagger": "^1.1.9",
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.0.0",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
 
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
@@ -140,6 +135,5 @@
     "babel-preset-expo": "^10.0.1",
     "lovable-tagger": "^1.1.9",
     "vite": "^5.0.0"
- main
   }
 }


### PR DESCRIPTION
## Summary
- remove stray codex and main lines from package.json
- ensure dev dependency list stays valid JSON

## Testing
- `jq empty package.json`
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68951b645cfc83319b392e191abad988