### PR TITLE
refactor: replace alias imports with relative paths

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,9 +1,9 @@
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { AlertTriangle, RefreshCw } from 'lucide-react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { PulseButton } from '@/components/ui/pulse-button';
-import { useErrorReporter } from '@/hooks/use-error-reporter';
-import { isDevelopment } from '@/config';
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
+import { PulseButton } from './ui/pulse-button';
+import { useErrorReporter } from '../hooks/use-error-reporter';
+import { isDevelopment } from '../config';
 
 interface Props {
   children: ReactNode;

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '../../contexts/AuthContext';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;

--- a/src/components/auth/auth-card.tsx
+++ b/src/components/auth/auth-card.tsx
@@ -1,16 +1,16 @@
 import React, { useState } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { PulseButton } from '@/components/ui/pulse-button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card';
+import { PulseButton } from '../ui/pulse-button';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
 import { Heart, Shield, Users, Copy, Apple, Chrome } from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { useAuth } from '@/contexts/AuthContext';
+import { cn } from '../../lib/utils';
+import { useAuth } from '../../contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
-import { useToast } from '@/hooks/use-toast';
-import { useTranslation } from '@/i18n';
-import { supabase } from '@/integrations/supabase/client';
-import { SITE_URL } from '@/config';
+import { useToast } from '../../hooks/use-toast';
+import { useTranslation } from '../../i18n';
+import { supabase } from '../../integrations/supabase/client';
+import { SITE_URL } from '../../config';
 
 
 const EU_COUNTRIES = [

--- a/src/components/calendar/shared-calendar.tsx
+++ b/src/components/calendar/shared-calendar.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { PulseButton } from "@/components/ui/pulse-button";
-import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
+import { PulseButton } from '../ui/pulse-button';
+import { Badge } from '../ui/badge';
 import {
   Calendar,
   Clock,
@@ -11,13 +11,13 @@ import {
   Trash2,
   Pencil,
 } from "lucide-react";
-import { cn } from "@/lib/utils";
-import { supabase } from "@/integrations/supabase/client";
-import { useAuth } from "@/contexts/AuthContext";
-import { scheduleReminder } from "@/lib/reminders";
-import { useTranslation } from "@/i18n";
-import { ProgressRing } from "@/components/ui/progress-ring";
-import { getConfetti } from "@/lib/confetti";
+import { cn } from '../../lib/utils';
+import { supabase } from '../../integrations/supabase/client';
+import { useAuth } from '../../contexts/AuthContext';
+import { scheduleReminder } from '../../lib/reminders';
+import { useTranslation } from '../../i18n';
+import { ProgressRing } from '../ui/progress-ring';
+import { getConfetti } from '../../lib/confetti';
 import type { Options as ConfettiOptions } from "canvas-confetti";
 import {
   Dialog,
@@ -26,12 +26,12 @@ import {
   DialogTitle,
   DialogFooter,
   DialogClose,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { fetchGoogleCalendarEvents } from "@/integrations/google-calendar";
-import { fetchMicrosoftCalendarEvents } from "@/integrations/microsoft-calendar";
-import { fetchEnergyCycleMetrics, type EnergyCycleMetrics } from "@/integrations/wearable";
+} from '../ui/dialog';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+import { fetchGoogleCalendarEvents } from '../../integrations/google-calendar';
+import { fetchMicrosoftCalendarEvents } from '../../integrations/microsoft-calendar';
+import { fetchEnergyCycleMetrics, type EnergyCycleMetrics } from '../../integrations/wearable';
 
 export interface TimeSlot {
   id: string;

--- a/src/components/communication/emoji-picker.tsx
+++ b/src/components/communication/emoji-picker.tsx
@@ -1,10 +1,10 @@
 import React, { useMemo, useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { PulseButton } from '@/components/ui/pulse-button';
-import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
+import { PulseButton } from '../ui/pulse-button';
+import { Badge } from '../ui/badge';
 import { Heart, Send, Sparkles } from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { useTranslation } from '@/i18n';
+import { cn } from '../../lib/utils';
+import { useTranslation } from '../../i18n';
 
 interface EmojiPickerProps {
   onSend: (emoji: string, category: string) => void;

--- a/src/components/coupling/pairing.tsx
+++ b/src/components/coupling/pairing.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { supabase } from '@/integrations/supabase/client';
-import type { Database } from '@/integrations/supabase/types';
-import { useAuth } from '@/contexts/AuthContext';
-import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
-import { Button } from '@/components/ui/button';
+import { supabase } from '../../integrations/supabase/client';
+import type { Database } from '../../integrations/supabase/types';
+import { useAuth } from '../../contexts/AuthContext';
+import { Avatar, AvatarImage, AvatarFallback } from '../ui/avatar';
+import { Button } from '../ui/button';
 import QRCode from 'qrcode.react';
-import { getConfetti } from '@/lib/confetti';
+import { getConfetti } from '../../lib/confetti';
 
 type ProfileSummary = Pick<
   Database['public']['Tables']['profiles']['Row'],

--- a/src/components/dashboard/central-pulse-button.tsx
+++ b/src/components/dashboard/central-pulse-button.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { Check } from 'lucide-react';
-import { useAuth } from '@/contexts/AuthContext';
-import { supabase } from '@/integrations/supabase/client';
-import { useToast } from '@/hooks/use-toast';
-import { useTranslation } from '@/i18n';
-import { cn } from '@/lib/utils';
+import { useAuth } from '../../contexts/AuthContext';
+import { supabase } from '../../integrations/supabase/client';
+import { useToast } from '../../hooks/use-toast';
+import { useTranslation } from '../../i18n';
+import { cn } from '../../lib/utils';
 
 interface CentralPulseButtonProps {
   className?: string;

--- a/src/components/dashboard/pulse-status.tsx
+++ b/src/components/dashboard/pulse-status.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { CentralPulseButton } from './central-pulse-button';
-import { StatusIndicator } from '@/components/ui/status-indicator';
+import { StatusIndicator } from '../ui/status-indicator';
 import { Heart, Moon, Coffee, Sparkles } from 'lucide-react';
-import { cn } from '@/lib/utils';
+import { cn } from '../../lib/utils';
 import { SnoozeToggle } from './snooze-toggle';
-import { useTranslation } from '@/i18n';
+import { useTranslation } from '../../i18n';
 
 type PulseStatus = 'active' | 'away' | 'offline';
 

--- a/src/components/dashboard/snooze-toggle.tsx
+++ b/src/components/dashboard/snooze-toggle.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
-import { Button } from '@/components/ui/button';
-import { supabase } from '@/integrations/supabase/client';
-import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group';
+import { Button } from '../ui/button';
+import { supabase } from '../../integrations/supabase/client';
+import { useAuth } from '../../contexts/AuthContext';
+import { useToast } from '../../hooks/use-toast';
 import { format } from 'date-fns';
 
 export const SnoozeToggle: React.FC = () => {

--- a/src/components/messaging/message-center.tsx
+++ b/src/components/messaging/message-center.tsx
@@ -1,17 +1,17 @@
 import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import type { InfiniteData } from '@tanstack/react-query';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { PulseButton } from '@/components/ui/pulse-button';
-import { Badge } from '@/components/ui/badge';
-import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
+import { PulseButton } from '../ui/pulse-button';
+import { Badge } from '../ui/badge';
+import { Textarea } from '../ui/textarea';
 import { MessageCircle, Send, Heart, Image, Smile } from 'lucide-react';
-import { cn } from '@/lib/utils';
-import { useAuth } from '@/contexts/AuthContext';
-import { supabase } from '@/integrations/supabase/client';
-import { useToast } from '@/hooks/use-toast';
-import { useTranslation } from '@/i18n';
+import { cn } from '../../lib/utils';
+import { useAuth } from '../../contexts/AuthContext';
+import { supabase } from '../../integrations/supabase/client';
+import { useToast } from '../../hooks/use-toast';
+import { useTranslation } from '../../i18n';
 import { FixedSizeList as List } from 'react-window';
-import { useMessages } from '@/hooks/use-messages';
+import { useMessages } from '../../hooks/use-messages';
 
 interface Message {
   id: string;

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/lib/utils"
+import { cn } from '../../lib/utils'
 
 const alertVariants = cva(
   "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/lib/utils"
+import { cn } from '../../lib/utils'
 
 const badgeVariants = cva(
   "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { DayPicker } from "react-day-picker";
 
-import { cn } from "@/lib/utils";
-import { buttonVariants } from "@/components/ui/button";
+import { cn } from '../../lib/utils';
+import { buttonVariants } from './button';
 
 export type CalendarProps = React.ComponentProps<typeof DayPicker>;
 

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn } from '../../lib/utils'
 
 const Card = React.forwardRef<
   HTMLDivElement,

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -4,8 +4,8 @@ import useEmblaCarousel, {
 } from "embla-carousel-react"
 import { ArrowLeft, ArrowRight } from "lucide-react"
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
+import { cn } from '../../lib/utils'
+import { Button } from './button'
 
 type CarouselApi = UseEmblaCarouselType[1]
 type UseCarouselParameters = Parameters<typeof useEmblaCarousel>

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as RechartsPrimitive from "recharts"
 
-import { cn } from "@/lib/utils"
+import { cn } from '../../lib/utils'
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { Drawer as DrawerPrimitive } from "vaul"
 
-import { cn } from "@/lib/utils"
+import { cn } from '../../lib/utils'
 
 const Drawer = ({
   shouldScaleBackground = true,

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { OTPInput, OTPInputContext } from "input-otp"
 import { Dot } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from '../../lib/utils'
 
 const InputOTP = React.forwardRef<
   React.ElementRef<typeof OTPInput>,

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 
-import { useTranslation } from "@/i18n"
-import { cn } from "@/lib/utils"
-import { useScaledFont } from "@/hooks/use-scaled-font"
+import { useTranslation } from '../../i18n'
+import { cn } from '../../lib/utils'
+import { useScaledFont } from '../../hooks/use-scaled-font'
 
 type InputProps = React.ComponentProps<"input"> & {
   maxLength?: number

--- a/src/components/ui/language-switcher.tsx
+++ b/src/components/ui/language-switcher.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
-import { useTranslation } from '@/i18n';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from './select';
+import { useTranslation } from '../../i18n';
 
 export const LanguageSwitcher: React.FC = () => {
   const { lang, setLang } = useTranslation();

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react"
 
-import { cn } from "@/lib/utils"
-import { ButtonProps, buttonVariants } from "@/components/ui/button"
+import { cn } from '../../lib/utils'
+import { ButtonProps, buttonVariants } from './button'
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
   <nav

--- a/src/components/ui/progress-ring.tsx
+++ b/src/components/ui/progress-ring.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { cn } from "@/lib/utils"
+import { cn } from '../../lib/utils'
 
 interface ProgressRingProps extends React.SVGProps<SVGSVGElement> {
   progress: number

--- a/src/components/ui/pulse-button.tsx
+++ b/src/components/ui/pulse-button.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TouchableOpacity, Text, StyleSheet, TouchableOpacityProps, ViewStyle, TextStyle } from 'react-native';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '../../contexts/AuthContext';
 
 export type PulseButtonVariant = 'pulse' | 'ghost' | 'soft' | 'intimate';
 export type PulseButtonSize = 'default' | 'sm' | 'lg' | 'xl';

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -1,7 +1,7 @@
 import { GripVertical } from "lucide-react"
 import * as ResizablePrimitive from "react-resizable-panels"
 
-import { cn } from "@/lib/utils"
+import { cn } from '../../lib/utils'
 
 const ResizablePanelGroup = ({
   className,

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils"
+import { cn } from '../../lib/utils'
 
 function Skeleton({
   className,

--- a/src/components/ui/status-indicator.tsx
+++ b/src/components/ui/status-indicator.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { cn } from '@/lib/utils';
+import { cn } from '../../lib/utils';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { useTranslation } from '@/i18n';
+import { useTranslation } from '../../i18n';
 
 const statusIndicatorVariants = cva(
   "inline-flex items-center gap-2 font-medium transition-all duration-300",

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn } from '../../lib/utils'
 
 const Table = React.forwardRef<
   HTMLTableElement,

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 
-import { useTranslation } from "@/i18n"
-import { cn } from "@/lib/utils"
-import { useScaledFont } from "@/hooks/use-scaled-font"
+import { useTranslation } from '../../i18n'
+import { cn } from '../../lib/utils'
+import { useScaledFont } from '../../hooks/use-scaled-font'
 
 export type TextareaProps =
   React.TextareaHTMLAttributes<HTMLTextAreaElement> & {

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,4 +1,4 @@
-import { useToast } from "@/hooks/use-toast"
+import { useToast } from '../../hooks/use-toast'
 import {
   Toast,
   ToastClose,
@@ -6,7 +6,7 @@ import {
   ToastProvider,
   ToastTitle,
   ToastViewport,
-} from "@/components/ui/toast"
+} from './toast'
 
 export function Toaster() {
   const { toasts } = useToast()

--- a/src/components/ui/use-toast.ts
+++ b/src/components/ui/use-toast.ts
@@ -1,3 +1,3 @@
-import { useToast, toast } from "@/hooks/use-toast";
+import { useToast, toast } from '../../hooks/use-toast';
 
 export { useToast, toast };

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,8 +1,8 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { User as SupabaseUser, Session } from '@supabase/supabase-js';
-import { supabase } from '@/integrations/supabase/client';
-import { useToast } from '@/hooks/use-toast';
-import * as authService from '@/services/auth';
+import { supabase } from '../integrations/supabase/client';
+import { useToast } from '../hooks/use-toast';
+import * as authService from '../services/auth';
 
 interface User {
   id: string;

--- a/src/hooks/use-messages.ts
+++ b/src/hooks/use-messages.ts
@@ -1,6 +1,6 @@
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase/client';
-import { Tables } from '@/integrations/supabase/types';
+import { supabase } from '../integrations/supabase/client';
+import { Tables } from '../integrations/supabase/types';
 
 const PAGE_SIZE = 20;
 

--- a/src/hooks/use-push-notifications.ts
+++ b/src/hooks/use-push-notifications.ts
@@ -1,9 +1,9 @@
 import { useEffect, useRef } from 'react';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '../integrations/supabase/client';
 import * as Notifications from 'expo-notifications';
-import { VAPID_PUBLIC_KEY } from '@/config';
+import { VAPID_PUBLIC_KEY } from '../config';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '../contexts/AuthContext';
 
 const TRIAL_START_KEY = 'trialStartDate';
 const TRIAL_NOTIFICATION_ID_KEY = 'trialNotificationId';

--- a/src/hooks/use-toast-notification.ts
+++ b/src/hooks/use-toast-notification.ts
@@ -1,5 +1,5 @@
-import { useToast } from '@/hooks/use-toast';
-import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from './use-toast';
+import { useAuth } from '../contexts/AuthContext';
 
 interface ToastNotificationOptions {
   title: string;

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -3,7 +3,7 @@ import * as React from "react"
 import type {
   ToastActionElement,
   ToastProps,
-} from "@/components/ui/toast"
+} from '../components/ui/toast'
 
 const TOAST_LIMIT = 1
 const TOAST_REMOVE_DELAY = 1000

--- a/src/integrations/google-calendar.ts
+++ b/src/integrations/google-calendar.ts
@@ -1,4 +1,4 @@
-import type { TimeSlot } from '@/components/calendar/shared-calendar';
+import type { TimeSlot } from '../components/calendar/shared-calendar';
 
 const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID;
 

--- a/src/integrations/microsoft-calendar.ts
+++ b/src/integrations/microsoft-calendar.ts
@@ -1,4 +1,4 @@
-import type { TimeSlot } from '@/components/calendar/shared-calendar';
+import type { TimeSlot } from '../components/calendar/shared-calendar';
 
 const MICROSOFT_CLIENT_ID = import.meta.env.VITE_MICROSOFT_CLIENT_ID;
 

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -3,10 +3,10 @@ import 'react-native-url-polyfill/auto';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
-import { SUPABASE_URL, SUPABASE_KEY } from '@/config';
+import { SUPABASE_URL, SUPABASE_KEY } from '../../config';
 
 // Import the supabase client like this:
-// import { supabase } from "@/integrations/supabase/client";
+// import { supabase } from './client';
 
 export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_KEY, {
   auth: {

--- a/src/lib/reminders.ts
+++ b/src/lib/reminders.ts
@@ -1,5 +1,5 @@
-import { supabase } from '@/integrations/supabase/client';
-import { withRetry } from '@/lib/retry';
+import { supabase } from '../integrations/supabase/client';
+import { withRetry } from './retry';
 
 interface ReminderSlot {
   id: string;

--- a/src/onboarding/AvatarSetup.tsx
+++ b/src/onboarding/AvatarSetup.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
-import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { PulseButton } from '@/components/ui/pulse-button';
-import { supabase } from '@/integrations/supabase/client';
-import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
+import { Avatar, AvatarImage, AvatarFallback } from '../components/ui/avatar';
+import { Input } from '../components/ui/input';
+import { Label } from '../components/ui/label';
+import { PulseButton } from '../components/ui/pulse-button';
+import { supabase } from '../integrations/supabase/client';
+import { useAuth } from '../contexts/AuthContext';
+import { useToast } from '../hooks/use-toast';
 
 export const AvatarSetup: React.FC = () => {
   const { user } = useAuth();

--- a/src/onboarding/StepEmail.tsx
+++ b/src/onboarding/StepEmail.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { AuthCard } from '@/components/auth/auth-card';
+import { AuthCard } from '../components/auth/auth-card';
 
 export const StepEmail: React.FC = () => {
   const [mode, setMode] = useState<'login' | 'register' | 'connect'>('login');

--- a/src/onboarding/StepIntro.tsx
+++ b/src/onboarding/StepIntro.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Carousel, CarouselContent, CarouselItem, CarouselPrevious, CarouselNext } from '@/components/ui/carousel';
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
-import { PulseButton } from '@/components/ui/pulse-button';
-import { useAuth } from '@/contexts/AuthContext';
-import { useTranslation } from '@/i18n';
-import { LanguageSwitcher } from '@/components/ui/language-switcher';
+import { Carousel, CarouselContent, CarouselItem, CarouselPrevious, CarouselNext } from '../components/ui/carousel';
+import { Card, CardHeader, CardTitle, CardContent } from '../components/ui/card';
+import { PulseButton } from '../components/ui/pulse-button';
+import { useAuth } from '../contexts/AuthContext';
+import { useTranslation } from '../i18n';
+import { LanguageSwitcher } from '../components/ui/language-switcher';
 
 export const StepIntro: React.FC = () => {
   const navigate = useNavigate();

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react';
-import { PulseButton } from '@/components/ui/pulse-button';
+import { PulseButton } from '../components/ui/pulse-button';
 import { Heart, Shield, Calendar, Sparkles, ArrowRight } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { useAuth } from '@/contexts/AuthContext';
-import { useTranslation } from '@/i18n';
-import heroImage from '@/assets/pulse-hero.jpg';
+import { useAuth } from '../contexts/AuthContext';
+import { useTranslation } from '../i18n';
+import heroImage from '../assets/pulse-hero.jpg';
 
 const Index = () => {
   const navigate = useNavigate();

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,7 +1,7 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
 import { View, Text, TouchableOpacity, StyleSheet, Linking } from "react-native";
-import logger from '@/lib/logger';
+import logger from '../lib/logger';
 
 const NotFound = () => {
   const location = useLocation();

--- a/src/pages/auth.tsx
+++ b/src/pages/auth.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { AuthCard } from '@/components/auth/auth-card';
-import heroImage from '@/assets/pulse-hero.jpg';
+import { AuthCard } from '../components/auth/auth-card';
+import heroImage from '../assets/pulse-hero.jpg';
 import { useSearchParams } from 'react-router-dom';
-import { LanguageSwitcher } from '@/components/ui/language-switcher';
+import { LanguageSwitcher } from '../components/ui/language-switcher';
 
 const Auth = () => {
   const [searchParams] = useSearchParams();

--- a/src/pages/calendar.tsx
+++ b/src/pages/calendar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { SharedCalendar } from '@/components/calendar/shared-calendar';
-import { PulseButton } from '@/components/ui/pulse-button';
+import { SharedCalendar } from '../components/calendar/shared-calendar';
+import { PulseButton } from '../components/ui/pulse-button';
 import { ArrowLeft } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Label } from '@/components/ui/label';
-import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
-import { PulseButton } from '@/components/ui/pulse-button';
-import { useToast } from '@/hooks/use-toast';
-import { useAuth } from '@/contexts/AuthContext';
-import { useTranslation } from '@/i18n';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+import { Label } from '../components/ui/label';
+import { Input } from '../components/ui/input';
+import { Textarea } from '../components/ui/textarea';
+import { PulseButton } from '../components/ui/pulse-button';
+import { useToast } from '../hooks/use-toast';
+import { useAuth } from '../contexts/AuthContext';
+import { useTranslation } from '../i18n';
 
 const Contact: React.FC = () => {
   const { user } = useAuth();

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
-import { PulseStatusCard } from '@/components/dashboard/pulse-status';
-import { EmojiPicker } from '@/components/communication/emoji-picker';
-import { SharedCalendar } from '@/components/calendar/shared-calendar';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { PulseButton } from '@/components/ui/pulse-button';
-import { Badge } from '@/components/ui/badge';
+import { PulseStatusCard } from '../components/dashboard/pulse-status';
+import { EmojiPicker } from '../components/communication/emoji-picker';
+import { SharedCalendar } from '../components/calendar/shared-calendar';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+import { PulseButton } from '../components/ui/pulse-button';
+import { Badge } from '../components/ui/badge';
 import { Heart, Bell, Settings, Shield, Calendar, MessageCircle, LogOut, User, Sparkles } from 'lucide-react';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '../contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
-import { useTranslation } from '@/i18n';
-import logger from '@/lib/logger';
+import { useTranslation } from '../i18n';
+import logger from '../lib/logger';
 
 const Dashboard = () => {
   const { user, logout } = useAuth();

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -4,11 +4,11 @@ import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
-} from '@/components/ui/accordion';
-import { PulseButton } from '@/components/ui/pulse-button';
-import { Textarea } from '@/components/ui/textarea';
-import logger from '@/lib/logger';
-import { useTranslation } from '@/i18n';
+} from '../components/ui/accordion';
+import { PulseButton } from '../components/ui/pulse-button';
+import { Textarea } from '../components/ui/textarea';
+import logger from '../lib/logger';
+import { useTranslation } from '../i18n';
 
 interface FAQItem {
   question: string;

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
-import { useScaledFont } from '@/hooks/use-scaled-font';
-import { supabase } from '@/integrations/supabase/client';
-import { useAuth } from '@/contexts/AuthContext';
-import { PulseButton } from '@/components/ui/pulse-button';
-import logger from '@/lib/logger';
+import { useScaledFont } from '../hooks/use-scaled-font';
+import { supabase } from '../integrations/supabase/client';
+import { useAuth } from '../contexts/AuthContext';
+import { PulseButton } from '../components/ui/pulse-button';
+import logger from '../lib/logger';
 
 interface Pulse {
   id: string;

--- a/src/pages/insights.tsx
+++ b/src/pages/insights.tsx
@@ -1,15 +1,15 @@
 import React, { useEffect, useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { PulseButton } from '@/components/ui/pulse-button';
-import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+import { PulseButton } from '../components/ui/pulse-button';
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from '../components/ui/chart';
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts';
 import { Sparkles, BarChart3, ArrowLeft, Heart } from 'lucide-react';
-import { useAuth } from '@/contexts/AuthContext';
-import { supabase } from '@/integrations/supabase/client';
-import { fetchEnergyCycleMetrics } from '@/integrations/wearable';
+import { useAuth } from '../contexts/AuthContext';
+import { supabase } from '../integrations/supabase/client';
+import { fetchEnergyCycleMetrics } from '../integrations/wearable';
 import { useNavigate } from 'react-router-dom';
-import { cn } from '@/lib/utils';
-import { useTranslation } from '@/i18n';
+import { cn } from '../lib/utils';
+import { useTranslation } from '../i18n';
 
 interface PulseRecord {
   created_at: string;

--- a/src/pages/messages.tsx
+++ b/src/pages/messages.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { MessageCenter } from '@/components/messaging/message-center';
-import { EmojiPicker } from '@/components/communication/emoji-picker';
-import { PulseButton } from '@/components/ui/pulse-button';
+import { MessageCenter } from '../components/messaging/message-center';
+import { EmojiPicker } from '../components/communication/emoji-picker';
+import { PulseButton } from '../components/ui/pulse-button';
 import { ArrowLeft } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import logger from '@/lib/logger';
-import { useAuth } from '@/contexts/AuthContext';
+import logger from '../lib/logger';
+import { useAuth } from '../contexts/AuthContext';
 
 const Messages: React.FC = () => {
   const navigate = useNavigate();

--- a/src/pages/pair.tsx
+++ b/src/pages/pair.tsx
@@ -1,4 +1,4 @@
-import Pairing from '@/components/coupling/pairing';
+import Pairing from '../components/coupling/pairing';
 
 const PairPage = () => <Pairing />;
 

--- a/src/pages/paywall.tsx
+++ b/src/pages/paywall.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { PulseButton } from '@/components/ui/pulse-button';
+import { PulseButton } from '../components/ui/pulse-button';
 import { Heart, Shield, Sparkles } from 'lucide-react';
-import { useTranslation } from '@/i18n';
+import { useTranslation } from '../i18n';
 
 const Paywall = () => {
   const { t } = useTranslation();

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,24 +1,24 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { PulseButton } from '@/components/ui/pulse-button';
-import { Badge } from '@/components/ui/badge';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import { Switch } from '@/components/ui/switch';
-import { Separator } from '@/components/ui/separator';
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Progress } from '@/components/ui/progress';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+import { PulseButton } from '../components/ui/pulse-button';
+import { Badge } from '../components/ui/badge';
+import { Input } from '../components/ui/input';
+import { Label } from '../components/ui/label';
+import { Textarea } from '../components/ui/textarea';
+import { Switch } from '../components/ui/switch';
+import { Separator } from '../components/ui/separator';
+import { Avatar, AvatarFallback, AvatarImage } from '../components/ui/avatar';
+import { Progress } from '../components/ui/progress';
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '@/components/ui/select';
+} from '../components/ui/select';
 
-import { useToast } from '@/hooks/use-toast';
-import { useTranslation } from '@/i18n';
+import { useToast } from '../hooks/use-toast';
+import { useTranslation } from '../i18n';
 
 import {
   Settings as SettingsIcon,
@@ -36,12 +36,12 @@ import {
   ArrowLeft,
   Sparkles,
 } from 'lucide-react';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '../contexts/AuthContext';
 import { Link, useNavigate } from 'react-router-dom';
-import { cn } from '@/lib/utils';
-import logger from '@/lib/logger';
-import { supabase } from '@/integrations/supabase/client';
-import type { Tables, TablesUpdate } from '@/integrations/supabase/types';
+import { cn } from '../lib/utils';
+import logger from '../lib/logger';
+import { supabase } from '../integrations/supabase/client';
+import type { Tables, TablesUpdate } from '../integrations/supabase/types';
 
 
 

--- a/src/pages/surprise-mode.tsx
+++ b/src/pages/surprise-mode.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { PulseButton } from '@/components/ui/pulse-button';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+import { PulseButton } from '../components/ui/pulse-button';
 import { ArrowLeft, Sparkles } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { Input } from '@/components/ui/input';
-import { useAuth } from '@/contexts/AuthContext';
-import { useToast } from '@/hooks/use-toast';
-import { scheduleSurprise } from '@/lib/reminders';
+import { Input } from '../components/ui/input';
+import { useAuth } from '../contexts/AuthContext';
+import { useToast } from '../hooks/use-toast';
+import { scheduleSurprise } from '../lib/reminders';
 
 const SurpriseMode: React.FC = () => {
   const [ideas, setIdeas] = useState<string[]>([]);

--- a/src/services/auth.test.ts
+++ b/src/services/auth.test.ts
@@ -1,13 +1,13 @@
 import { vi } from 'vitest';
 
-vi.mock('@/lib/retry', () => ({
+vi.mock('../lib/retry', () => ({
   withRetry: (fn: any) => fn(),
 }));
 
-vi.mock('@/config', () => ({ SITE_URL: 'https://example.com' }));
+vi.mock('../config', () => ({ SITE_URL: 'https://example.com' }));
 
 import { signIn, signUp, connectPartner, connectByCode } from './auth';
-import { supabase } from '@/integrations/supabase/client';
+import { supabase } from '../integrations/supabase/client';
 
 test('signIn calls supabase auth method', async () => {
   await signIn('test@example.com', 'password');

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,6 +1,6 @@
-import { supabase } from '@/integrations/supabase/client';
-import { withRetry } from '@/lib/retry';
-import { SITE_URL } from '@/config';
+import { supabase } from '../integrations/supabase/client';
+import { withRetry } from '../lib/retry';
+import { SITE_URL } from '../config';
 
 export const signIn = (email: string, password: string) => {
   return withRetry(() => supabase.auth.signInWithPassword({ email, password }));


### PR DESCRIPTION
## Summary
- replace alias imports using `@/` with relative paths across source files
- ensure TypeScript paths resolve using `tsc`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68960caad9a483318a6f54c710bf27af