### PR TITLE
feat: add snack entry

### DIFF
--- a/App.snack.tsx
+++ b/App.snack.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Snack Preview</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    fontSize: 18,
+  },
+});

--- a/app.snack.json
+++ b/app.snack.json
@@ -1,0 +1,7 @@
+{
+  "expo": {
+    "name": "pulse-snack",
+    "slug": "pulse-snack",
+    "entryPoint": "./App.snack.tsx"
+  }
+}


### PR DESCRIPTION
## Summary
- add simple Snack-specific entry component
- provide standalone app.snack.json pointing to the Snack entry

## Testing
- `npm test` *(fails: Expected 'from', got 'typeOf')*

------
https://chatgpt.com/codex/tasks/task_e_689618a70a2083319964bebdc7ecd88a