### PR TITLE
chore: ensure supabase polyfill in auth context

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,3 +1,4 @@
+import 'react-native-url-polyfill/auto';
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { User as SupabaseUser, Session } from '@supabase/supabase-js';
 import { supabase } from '../integrations/supabase/client';


### PR DESCRIPTION
## Summary
- ensure URL polyfill loads before Supabase types in AuthContext

## Testing
- `npm test` *(fails: Expected 'from', got 'typeOf')*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_689618a80acc83318b5e8f65e5f8c35f