### PR TITLE
Add JS entry point for Snack preview

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,0 +1,3 @@
+import App from './App.snack';
+export default App;
+

--- a/app.snack.json
+++ b/app.snack.json
@@ -2,6 +2,6 @@
   "expo": {
     "name": "pulse-snack",
     "slug": "pulse-snack",
-    "entryPoint": "./App.snack.tsx"
+    "entryPoint": "./App.js"
   }
 }


### PR DESCRIPTION
## Summary
- add App.js re-export to support Snack
- point Snack config to App.js entry

## Testing
- `npm test` *(fails: FAIL src/services/auth.test.ts [ src/services/auth.test.ts ])*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68966192d74083319180157b9004cb1d